### PR TITLE
Fix: Add basePath for GitHub Pages deployment

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,8 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "export",
+  basePath: "/lesdeuxchevaux",
+  assetPrefix: "/lesdeuxchevaux",
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
Adds basePath and assetPrefix configuration so CSS and assets load correctly on GitHub Pages subdirectory deployment.