### PR TITLE
Fix image paths for GitHub Pages and add logo prompt

### DIFF
--- a/LOGO_PROMPT.md
+++ b/LOGO_PROMPT.md
@@ -1,0 +1,43 @@
+# Logo Prompt for Les Deux Chevaux
+
+Use this prompt with an AI image generator (DALL-E, Midjourney, etc.) to create a logo for Les Deux Chevaux.
+
+## Prompt
+
+```
+Create a clean, minimalist logo for "Les Deux Chevaux", a charming mini-camping and bed & breakfast in the French countryside of Auvergne.
+
+Design requirements:
+- Feature a stylized Citroën 2CV car (the iconic French "deux chevaux" / two horsepower car)
+- Use warm, earthy colors: amber, terracotta, cream, or olive green
+- Clean, modern design with a vintage French countryside feel
+- The 2CV should be simple and recognizable, not overly detailed
+- Include the text "Les Deux Chevaux" in an elegant but readable font
+- Suitable for both web headers and print materials
+- Works well on both light and dark backgrounds
+- Evokes feelings of relaxation, authenticity, and French rural charm
+
+Style: Modern minimalist with subtle vintage touches, similar to boutique hospitality logos
+Aspect ratio: Horizontal/landscape orientation for website header use
+Background: Transparent or simple solid color
+```
+
+## Alternative Variations to Try
+
+### Icon-Only Version
+```
+Create a simple icon/symbol of a Citroën 2CV car in a minimalist style. Use a single warm color (amber or terracotta). Clean lines, no text, suitable as a favicon or social media profile picture.
+```
+
+### Text-Focused Version
+```
+Create elegant typography for "Les Deux Chevaux" with a tiny, subtle 2CV car silhouette integrated into or near the text. Warm amber/brown color palette. Clean and modern with French countryside charm.
+```
+
+## Brand Context
+
+- **Business**: Mini-camping, chambres d'hôtes (B&B), and table d'hôtes in Auvergne, France
+- **Name meaning**: "Les Deux Chevaux" refers to the iconic Citroën 2CV car ("two horsepower")
+- **Vibe**: Relaxed, authentic French countryside experience
+- **Target audience**: Tourists seeking peaceful, genuine French rural hospitality
+- **Owners**: Yvonne and Rob, a Dutch couple living their French dream

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { getImagePath } from "@/lib/config";
 
 interface CardProps {
   title: string;
@@ -14,7 +15,7 @@ export default function Card({ title, description, image, href }: CardProps) {
       {image && (
         <div className="relative h-48 overflow-hidden">
           <Image
-            src={image}
+            src={getImagePath(image)}
             alt={title}
             fill
             className="object-cover group-hover:scale-105 transition-transform duration-300"

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { getImagePath } from "@/lib/config";
 
 interface HeroProps {
   title: string;
@@ -19,7 +20,7 @@ export default function Hero({
     >
       {image && (
         <Image
-          src={image}
+          src={getImagePath(image)}
           alt={title}
           fill
           className="object-cover"

--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { useState } from "react";
+import { getImagePath } from "@/lib/config";
 
 interface ImageGalleryProps {
   images: {
@@ -23,7 +24,7 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
             className="relative aspect-square overflow-hidden rounded-lg hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
           >
             <Image
-              src={image.src}
+              src={getImagePath(image.src)}
               alt={image.alt}
               fill
               className="object-cover"
@@ -87,7 +88,7 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
             onClick={(e) => e.stopPropagation()}
           >
             <Image
-              src={images[selectedImage].src}
+              src={getImagePath(images[selectedImage].src)}
               alt={images[selectedImage].alt}
               fill
               className="object-contain"

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,8 @@
+// Base path for GitHub Pages deployment
+export const basePath = process.env.NODE_ENV === "production" ? "/lesdeuxchevaux" : "";
+
+// Helper to prefix image paths with basePath
+export function getImagePath(path: string): string {
+  if (path.startsWith("http")) return path;
+  return `${basePath}${path}`;
+}


### PR DESCRIPTION
## Summary
- Fix broken images on GitHub Pages by adding `getImagePath()` helper that prefixes image paths with basePath in production
- Add `LOGO_PROMPT.md` with AI generation prompts for creating the Les Deux Chevaux logo

## Changes
- `src/lib/config.ts`: New helper for image path prefixing
- `src/components/Hero.tsx`: Use getImagePath for hero images
- `src/components/Card.tsx`: Use getImagePath for card images  
- `src/components/ImageGallery.tsx`: Use getImagePath for gallery and lightbox images
- `LOGO_PROMPT.md`: Prompts for AI logo generation

## Test plan
- [ ] Verify images load correctly on https://basnijholt.github.io/lesdeuxchevaux/ after deployment
- [ ] Check logo prompt file is accessible in repo