### PR TITLE
Fix image paths in all page components

### DIFF
--- a/src/app/de-streek/page.tsx
+++ b/src/app/de-streek/page.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import type { Metadata } from "next";
 import Hero from "@/components/Hero";
 import ImageGallery from "@/components/ImageGallery";
+import { getImagePath } from "@/lib/config";
 
 export const metadata: Metadata = {
   title: "De streek",
@@ -156,7 +157,7 @@ export default function DeStreek() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
             <div className="relative h-96 rounded-xl overflow-hidden shadow-lg">
               <Image
-                src="/uploads/2018/11/winter-e1543590063310-768x1024.jpg"
+                src={getImagePath("/uploads/2018/11/winter-e1543590063310-768x1024.jpg")}
                 alt="Winter in Auvergne"
                 fill
                 className="object-cover"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import Hero from "@/components/Hero";
 import Card from "@/components/Card";
 import ImageGallery from "@/components/ImageGallery";
+import { getImagePath } from "@/lib/config";
 
 const highlights = [
   {
@@ -100,7 +101,7 @@ export default function Home() {
             </div>
             <div className="relative h-80 rounded-xl overflow-hidden shadow-lg">
               <Image
-                src="/uploads/2020/07/les-deux-chevaux2-1024x682.jpg"
+                src={getImagePath("/uploads/2020/07/les-deux-chevaux2-1024x682.jpg")}
                 alt="Les Deux Chevaux - De iconische 2CV"
                 fill
                 className="object-cover"

--- a/src/app/waar-zijn-wij/page.tsx
+++ b/src/app/waar-zijn-wij/page.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import type { Metadata } from "next";
 import Hero from "@/components/Hero";
+import { getImagePath } from "@/lib/config";
 
 export const metadata: Metadata = {
   title: "Waar zitten wij?",
@@ -66,7 +67,7 @@ export default function WaarZijnWij() {
             <div className="space-y-6">
               <div className="relative h-64 rounded-xl overflow-hidden shadow-lg">
                 <Image
-                  src="/uploads/2020/07/landschap-panorama-1024x405.jpg"
+                  src={getImagePath("/uploads/2020/07/landschap-panorama-1024x405.jpg")}
                   alt="Panorama van het landschap"
                   fill
                   className="object-cover"

--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import type { Metadata } from "next";
 import Hero from "@/components/Hero";
 import ImageGallery from "@/components/ImageGallery";
+import { getImagePath } from "@/lib/config";
 
 export const metadata: Metadata = {
   title: "Wat te verwachten?",
@@ -88,7 +89,7 @@ export default function WatTeVerwachten() {
           </div>
           <div className="relative h-80 rounded-xl overflow-hidden shadow-lg max-w-3xl mx-auto">
             <Image
-              src="/uploads/2016/09/Les-2CV-3-copy-1024x683.jpg"
+              src={getImagePath("/uploads/2016/09/Les-2CV-3-copy-1024x683.jpg")}
               alt="Groene Kamer"
               fill
               className="object-cover"
@@ -131,7 +132,7 @@ export default function WatTeVerwachten() {
             </div>
             <div className="relative h-80 rounded-xl overflow-hidden shadow-lg">
               <Image
-                src="/uploads/2020/07/camping-2-1024x656.jpg"
+                src={getImagePath("/uploads/2020/07/camping-2-1024x656.jpg")}
                 alt="Camping"
                 fill
                 className="object-cover"
@@ -207,7 +208,7 @@ export default function WatTeVerwachten() {
             </div>
             <div className="relative h-80 rounded-xl overflow-hidden shadow-lg">
               <Image
-                src="/uploads/2016/09/tafelen.jpg"
+                src={getImagePath("/uploads/2016/09/tafelen.jpg")}
                 alt="Table d'Hôtes"
                 fill
                 className="object-cover"

--- a/src/app/wie-zijn-wij/page.tsx
+++ b/src/app/wie-zijn-wij/page.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import type { Metadata } from "next";
 import Hero from "@/components/Hero";
+import { getImagePath } from "@/lib/config";
 
 export const metadata: Metadata = {
   title: "Wie zijn wij?",
@@ -41,7 +42,7 @@ export default function WieZijnWij() {
             </div>
             <div className="relative h-96 rounded-xl overflow-hidden shadow-lg">
               <Image
-                src="/uploads/2021/09/rob-en-yvonne-1.jpg"
+                src={getImagePath("/uploads/2021/09/rob-en-yvonne-1.jpg")}
                 alt="Yvonne en Rob"
                 fill
                 className="object-cover"
@@ -54,7 +55,7 @@ export default function WieZijnWij() {
           <div className="mt-16 grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
             <div className="relative h-96 rounded-xl overflow-hidden shadow-lg lg:order-first">
               <Image
-                src="/uploads/2021/09/jip-2.jpg"
+                src={getImagePath("/uploads/2021/09/jip-2.jpg")}
                 alt="Jip"
                 fill
                 className="object-cover"


### PR DESCRIPTION
## Summary
Fix all broken images on GitHub Pages by adding `getImagePath()` to page components that use the Image component directly.

## Pages fixed
- `page.tsx` (home) - 2CV image in "Why the name" section
- `wie-zijn-wij/page.tsx` - Rob & Yvonne photo, Jip photo
- `waar-zijn-wij/page.tsx` - Landscape panorama
- `de-streek/page.tsx` - Winter image
- `wat-te-verwachten/page.tsx` - Room, camping, and table d'hôtes images

## Test plan
- [ ] Verify all images load on https://basnijholt.github.io/lesdeuxchevaux/
- [ ] Check all subpages for working images