### PR TITLE
Add Dutch/French language support with toggle switch

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,21 +1,17 @@
-import type { Metadata } from "next";
+"use client";
 
-export const metadata: Metadata = {
-  title: "Contact",
-  description:
-    "Neem contact op met Les Deux Chevaux voor reserveringen of vragen. E-mail of bel ons!",
-};
+import { useTranslation } from "@/i18n";
 
 export default function Contact() {
+  const { t } = useTranslation();
+
   return (
     <>
       {/* Header */}
       <section className="py-16 bg-amber-800 text-white">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-center">
-          <h1 className="text-4xl font-bold mb-4">Contact</h1>
-          <p className="text-xl text-amber-100">
-            Neem contact met ons op voor meer informatie of een reservering
-          </p>
+          <h1 className="text-4xl font-bold mb-4">{t.nav.contact}</h1>
+          <p className="text-xl text-amber-100">{t.contact.heroSubtitle}</p>
         </div>
       </section>
 
@@ -25,7 +21,7 @@ export default function Contact() {
             {/* Contact Info */}
             <div>
               <h2 className="text-2xl font-bold text-amber-900 mb-8">
-                Contactgegevens
+                {t.contact.contactDetails}
               </h2>
 
               <div className="space-y-6">
@@ -47,7 +43,9 @@ export default function Contact() {
                     </svg>
                   </div>
                   <div>
-                    <h3 className="font-semibold text-gray-900">E-mail</h3>
+                    <h3 className="font-semibold text-gray-900">
+                      {t.common.email}
+                    </h3>
                     <a
                       href="mailto:lesdeuxchevaux@gmail.com"
                       className="text-amber-700 hover:text-amber-800 transition-colors"
@@ -76,7 +74,7 @@ export default function Contact() {
                   </div>
                   <div>
                     <h3 className="font-semibold text-gray-900">
-                      Telefoon Yvonne
+                      {t.contact.phoneYvonne}
                     </h3>
                     <a
                       href="tel:+33786141714"
@@ -105,7 +103,9 @@ export default function Contact() {
                     </svg>
                   </div>
                   <div>
-                    <h3 className="font-semibold text-gray-900">Telefoon Rob</h3>
+                    <h3 className="font-semibold text-gray-900">
+                      {t.contact.phoneRob}
+                    </h3>
                     <a
                       href="tel:+33768859020"
                       className="text-amber-700 hover:text-amber-800 transition-colors"
@@ -138,13 +138,15 @@ export default function Contact() {
                     </svg>
                   </div>
                   <div>
-                    <h3 className="font-semibold text-gray-900">Adres</h3>
+                    <h3 className="font-semibold text-gray-900">
+                      {t.common.address}
+                    </h3>
                     <address className="not-italic text-gray-600">
                       7 Impasse de la Tranquillité
                       <br />
                       Nades, Allier
                       <br />
-                      Auvergne, Frankrijk
+                      Auvergne, France
                     </address>
                   </div>
                 </div>
@@ -154,12 +156,12 @@ export default function Contact() {
             {/* Map */}
             <div>
               <h2 className="text-2xl font-bold text-amber-900 mb-8">
-                Locatie
+                {t.common.location}
               </h2>
               <div className="bg-gray-100 rounded-xl overflow-hidden h-80 flex items-center justify-center">
                 <div className="text-center p-8">
                   <p className="text-gray-600 mb-4">
-                    Bekijk onze locatie op Google Maps
+                    {t.contact.viewLocationText}
                   </p>
                   <a
                     href="https://www.google.com/maps/search/?api=1&query=7+Impasse+de+la+Tranquillité+Nades+France"
@@ -167,50 +169,10 @@ export default function Contact() {
                     rel="noopener noreferrer"
                     className="inline-block px-6 py-3 bg-amber-600 text-white font-semibold rounded-lg hover:bg-amber-700 transition-colors"
                   >
-                    Open in Google Maps
+                    {t.common.openInGoogleMaps}
                   </a>
                 </div>
               </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* French version */}
-      <section className="py-16 bg-amber-50">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="max-w-3xl">
-            <h2 className="text-2xl font-bold text-amber-900 mb-6">
-              Contactez-nous
-            </h2>
-            <p className="text-lg text-gray-600 mb-6">
-              Vous avez des questions ou souhaitez faire une réservation?
-              N&apos;hésitez pas à nous contacter!
-            </p>
-            <div className="bg-white p-6 rounded-xl">
-              <dl className="space-y-4">
-                <div>
-                  <dt className="font-semibold text-gray-900">E-mail</dt>
-                  <dd>
-                    <a
-                      href="mailto:lesdeuxchevaux@gmail.com"
-                      className="text-amber-700"
-                    >
-                      lesdeuxchevaux@gmail.com
-                    </a>
-                  </dd>
-                </div>
-                <div>
-                  <dt className="font-semibold text-gray-900">
-                    Téléphone Yvonne
-                  </dt>
-                  <dd>+33 786 141 714</dd>
-                </div>
-                <div>
-                  <dt className="font-semibold text-gray-900">Téléphone Rob</dt>
-                  <dd>+33 768 859 020</dd>
-                </div>
-              </dl>
             </div>
           </div>
         </div>

--- a/src/app/de-streek/page.tsx
+++ b/src/app/de-streek/page.tsx
@@ -1,75 +1,10 @@
+"use client";
+
 import Image from "next/image";
-import type { Metadata } from "next";
 import Hero from "@/components/Hero";
 import ImageGallery from "@/components/ImageGallery";
 import { getImagePath } from "@/lib/config";
-
-export const metadata: Metadata = {
-  title: "De streek",
-  description:
-    "Ontdek de prachtige Auvergne - wandelen, fietsen, kajakken en meer. De perfecte bestemming voor natuurliefhebbers.",
-};
-
-const activities = [
-  {
-    title: "Wandelen",
-    description:
-      "Talloze paden met verschillende moeilijkheidsgraden door het prachtige landschap.",
-    icon: "🥾",
-  },
-  {
-    title: "Mountainbiken",
-    description: "Een paradijs voor MTB-liefhebbers met uitdagende routes.",
-    icon: "🚵",
-  },
-  {
-    title: "Fietsen",
-    description: "Ontdek de streek op de fiets via schilderachtige wegen.",
-    icon: "🚴",
-  },
-  {
-    title: "Vissen",
-    description: "Vis in de rivier de Sioul, rijk aan diverse vissoorten.",
-    icon: "🎣",
-  },
-  {
-    title: "Kanoën",
-    description: "Vaar over de Sioul en geniet van de natuur vanaf het water.",
-    icon: "🛶",
-  },
-  {
-    title: "Paardrijden",
-    description: "Verken de omgeving te paard of met een ezel.",
-    icon: "🐴",
-  },
-];
-
-const attractions = [
-  {
-    title: "Puy de Dôme",
-    description: "Iconische vulkaan met adembenemend uitzicht.",
-  },
-  {
-    title: "Puy de Sancy",
-    description: "Hoogste berg in het Centraal Massief.",
-  },
-  {
-    title: "Kastelen en ruïnes",
-    description: "Rijk historisch erfgoed in de omgeving.",
-  },
-  {
-    title: "Parc Vulcania",
-    description: "Avontuurlijk themapark over vulkanen bij Clermont-Ferrand.",
-  },
-  {
-    title: "Automuseum Bellenave",
-    description: "Voor liefhebbers van klassieke auto's.",
-  },
-  {
-    title: "Rommelmarkten",
-    description: "Gezellige markten met unieke vondsten.",
-  },
-];
+import { useTranslation } from "@/i18n";
 
 const regionImages = [
   { src: "/uploads/2013/11/WS14.jpg", alt: "Landschap Auvergne" },
@@ -82,11 +17,73 @@ const regionImages = [
 ];
 
 export default function DeStreek() {
+  const { t } = useTranslation();
+
+  const activities = [
+    {
+      title: t.theRegion.activities.hiking.title,
+      description: t.theRegion.activities.hiking.description,
+      icon: "🥾",
+    },
+    {
+      title: t.theRegion.activities.mountainBiking.title,
+      description: t.theRegion.activities.mountainBiking.description,
+      icon: "🚵",
+    },
+    {
+      title: t.theRegion.activities.cycling.title,
+      description: t.theRegion.activities.cycling.description,
+      icon: "🚴",
+    },
+    {
+      title: t.theRegion.activities.fishing.title,
+      description: t.theRegion.activities.fishing.description,
+      icon: "🎣",
+    },
+    {
+      title: t.theRegion.activities.canoeing.title,
+      description: t.theRegion.activities.canoeing.description,
+      icon: "🛶",
+    },
+    {
+      title: t.theRegion.activities.horseRiding.title,
+      description: t.theRegion.activities.horseRiding.description,
+      icon: "🐴",
+    },
+  ];
+
+  const attractions = [
+    {
+      title: t.theRegion.attractions.puyDeDome.title,
+      description: t.theRegion.attractions.puyDeDome.description,
+    },
+    {
+      title: t.theRegion.attractions.puyDeSancy.title,
+      description: t.theRegion.attractions.puyDeSancy.description,
+    },
+    {
+      title: t.theRegion.attractions.castles.title,
+      description: t.theRegion.attractions.castles.description,
+    },
+    {
+      title: t.theRegion.attractions.vulcania.title,
+      description: t.theRegion.attractions.vulcania.description,
+    },
+    {
+      title: t.theRegion.attractions.autoMuseum.title,
+      description: t.theRegion.attractions.autoMuseum.description,
+    },
+    {
+      title: t.theRegion.attractions.fleaMarkets.title,
+      description: t.theRegion.attractions.fleaMarkets.description,
+    },
+  ];
+
   return (
     <>
       <Hero
-        title="Wat heeft de streek te bieden?"
-        subtitle="Ontdek de prachtige Auvergne"
+        title={t.theRegion.heroTitle}
+        subtitle={t.theRegion.heroSubtitle}
         image="/uploads/2013/11/WS14.jpg"
       />
 
@@ -94,14 +91,8 @@ export default function DeStreek() {
       <section className="py-16 bg-white">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="max-w-3xl mx-auto text-center">
-            <p className="text-xl text-gray-600 mb-4">
-              De Auvergne biedt het hele jaar door schoonheid met activiteiten
-              voor iedereen. Het is een plek waar je echt tot rust kunt komen.
-            </p>
-            <p className="text-lg text-gray-500">
-              Laat de technologie achter en geniet van een complete reset in de
-              natuur.
-            </p>
+            <p className="text-xl text-gray-600 mb-4">{t.theRegion.intro1}</p>
+            <p className="text-lg text-gray-500">{t.theRegion.intro2}</p>
           </div>
         </div>
       </section>
@@ -110,7 +101,7 @@ export default function DeStreek() {
       <section className="py-16 bg-amber-50">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-amber-900 text-center mb-12">
-            Buitenactiviteiten
+            {t.theRegion.outdoorActivities}
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
             {activities.map((activity) => (
@@ -133,7 +124,7 @@ export default function DeStreek() {
       <section className="py-16 bg-white">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-amber-900 text-center mb-12">
-            Attracties binnen 60 km
+            {t.theRegion.attractionsTitle}
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {attractions.map((attraction) => (
@@ -157,7 +148,9 @@ export default function DeStreek() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
             <div className="relative h-96 rounded-xl overflow-hidden shadow-lg">
               <Image
-                src={getImagePath("/uploads/2018/11/winter-e1543590063310-768x1024.jpg")}
+                src={getImagePath(
+                  "/uploads/2018/11/winter-e1543590063310-768x1024.jpg"
+                )}
                 alt="Winter in Auvergne"
                 fill
                 className="object-cover"
@@ -166,16 +159,12 @@ export default function DeStreek() {
             </div>
             <div>
               <h2 className="text-3xl font-bold text-amber-900 mb-6">
-                Ook in de winter
+                {t.theRegion.winterTitle}
               </h2>
               <p className="text-lg text-gray-600 mb-4">
-                De Auvergne is ook in de winter prachtig, met mogelijkheden voor
-                winterse wandelingen en het genieten van de rust.
+                {t.theRegion.winterText1}
               </p>
-              <p className="text-lg text-gray-600">
-                Geniet van de besneeuwde landschappen en de gezellige sfeer bij
-                de open haard.
-              </p>
+              <p className="text-lg text-gray-600">{t.theRegion.winterText2}</p>
             </div>
           </div>
         </div>
@@ -185,7 +174,7 @@ export default function DeStreek() {
       <section className="py-16 bg-white">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-amber-900 text-center mb-12">
-            Impressies van de streek
+            {t.theRegion.impressions}
           </h2>
           <ImageGallery images={regionImages} />
         </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono, Playfair_Display } from "next/font/google";
 import "./globals.css";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import { LanguageProvider } from "@/i18n";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -61,9 +62,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${playfair.variable} antialiased min-h-screen flex flex-col`}
       >
-        <Header />
-        <main className="flex-grow">{children}</main>
-        <Footer />
+        <LanguageProvider>
+          <Header />
+          <main className="flex-grow">{children}</main>
+          <Footer />
+        </LanguageProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
 import Hero from "@/components/Hero";
@@ -5,28 +7,7 @@ import Card from "@/components/Card";
 import ImageGallery from "@/components/ImageGallery";
 import FadeIn from "@/components/FadeIn";
 import { getImagePath } from "@/lib/config";
-
-const highlights = [
-  {
-    title: "Mini-Camping",
-    description:
-      "6 ruime plekken voor tent of caravan in een ontspannen sfeer",
-    image: "/uploads/2020/07/camping-2-1024x656.jpg",
-    href: "/wat-te-verwachten",
-  },
-  {
-    title: "Chambres d'Hôtes",
-    description: "Comfortabele kamers met heerlijk Frans ontbijt",
-    image: "/uploads/2016/09/Les-2CV-3-copy-1024x683.jpg",
-    href: "/wat-te-verwachten",
-  },
-  {
-    title: "Table d'Hôtes",
-    description: "Geniet van authentieke Franse maaltijden",
-    image: "/uploads/2016/09/tafelen.jpg",
-    href: "/tarieven",
-  },
-];
+import { useTranslation } from "@/i18n";
 
 const galleryImages = [
   { src: "/uploads/2020/07/onze-achterkant-1024x768.jpg", alt: "Achtertuin" },
@@ -39,11 +20,34 @@ const galleryImages = [
 ];
 
 export default function Home() {
+  const { t } = useTranslation();
+
+  const highlights = [
+    {
+      title: t.home.highlights.camping.title,
+      description: t.home.highlights.camping.description,
+      image: "/uploads/2020/07/camping-2-1024x656.jpg",
+      href: "/wat-te-verwachten",
+    },
+    {
+      title: t.home.highlights.chambres.title,
+      description: t.home.highlights.chambres.description,
+      image: "/uploads/2016/09/Les-2CV-3-copy-1024x683.jpg",
+      href: "/wat-te-verwachten",
+    },
+    {
+      title: t.home.highlights.table.title,
+      description: t.home.highlights.table.description,
+      image: "/uploads/2016/09/tafelen.jpg",
+      href: "/tarieven",
+    },
+  ];
+
   return (
     <>
       <Hero
         title="Les Deux Chevaux"
-        subtitle="Mini-camping, chambres d'hôtes en table d'hôtes in de Auvergne"
+        subtitle={t.home.heroSubtitle}
         image="/uploads/2020/07/2020-06-29-20.12.14-2-1024x682.jpg"
         fullHeight
       />
@@ -54,16 +58,13 @@ export default function Home() {
           <FadeIn>
             <div className="text-center max-w-3xl mx-auto">
               <h2 className="text-3xl md:text-4xl font-bold text-[#5C5840] mb-8 heading-decorated-center">
-                Welkom in de Auvergne
+                {t.home.welcomeTitle}
               </h2>
               <p className="text-lg md:text-xl text-gray-600 mb-6 leading-relaxed">
-                Welkom op de website van <strong>Les Deux Chevaux</strong>, een
-                gezellige mini-camping, chambres d&apos;hôtes (Bed & Breakfast) en
-                table d&apos;hôtes in het prachtige Auvergne, Frankrijk.
+                {t.home.welcomeText1}
               </p>
               <p className="text-lg md:text-xl text-gray-600 leading-relaxed">
-                Wij, Yvonne en Rob, heten u van harte welkom op ons stukje paradijs
-                in het hartje van Frankrijk.
+                {t.home.welcomeText2}
               </p>
             </div>
           </FadeIn>
@@ -75,7 +76,7 @@ export default function Home() {
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <FadeIn>
             <h2 className="text-3xl md:text-4xl font-bold text-[#5C5840] text-center mb-16 heading-decorated-center">
-              Wat bieden wij?
+              {t.home.whatWeOffer}
             </h2>
           </FadeIn>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
@@ -95,16 +96,13 @@ export default function Home() {
             <FadeIn direction="left">
               <div>
                 <h2 className="text-3xl md:text-4xl font-bold text-[#5C5840] mb-8 heading-decorated">
-                  Waarom &quot;Les Deux Chevaux&quot;?
+                  {t.home.whyTheName}
                 </h2>
                 <p className="text-lg text-gray-600 mb-6 leading-relaxed">
-                  De naam &quot;Les Deux Chevaux&quot; verwijst naar de iconische
-                  Franse auto, de Citroën 2CV - oftewel &quot;deux chevaux&quot;
-                  (twee paardenkrachten).
+                  {t.home.whyTheNameText1}
                 </p>
                 <p className="text-lg text-gray-600 leading-relaxed">
-                  Deze auto symboliseert het relaxte, authentieke Franse
-                  plattelandsleven dat wij onze gasten willen bieden.
+                  {t.home.whyTheNameText2}
                 </p>
               </div>
             </FadeIn>
@@ -112,7 +110,7 @@ export default function Home() {
               <div className="relative h-80 lg:h-96 rounded-2xl overflow-hidden shadow-xl">
                 <Image
                   src={getImagePath("/uploads/2020/07/les-deux-chevaux2-1024x682.jpg")}
-                  alt="Les Deux Chevaux - De iconische 2CV"
+                  alt="Les Deux Chevaux - 2CV"
                   fill
                   className="object-cover hover:scale-105 transition-transform duration-700"
                   sizes="(max-width: 1024px) 100vw, 50vw"
@@ -128,7 +126,7 @@ export default function Home() {
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <FadeIn>
             <h2 className="text-3xl md:text-4xl font-bold text-[#5C5840] text-center mb-16 heading-decorated-center">
-              Impressies
+              {t.home.impressions}
             </h2>
           </FadeIn>
           <FadeIn delay={200}>
@@ -142,18 +140,17 @@ export default function Home() {
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-center">
           <FadeIn>
             <h2 className="text-3xl md:text-4xl font-bold mb-8">
-              Klaar voor uw verblijf in de Auvergne?
+              {t.home.readyForStay}
             </h2>
             <p className="text-xl text-[#D4C9A8] mb-10 max-w-2xl mx-auto leading-relaxed">
-              Neem contact met ons op voor meer informatie of om een reservering
-              te maken.
+              {t.home.ctaText}
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link href="/contact" className="btn-white">
-                Neem contact op
+                {t.common.contact}
               </Link>
               <Link href="/tarieven" className="btn-outline-white">
-                Bekijk tarieven
+                {t.common.viewRates}
               </Link>
             </div>
           </FadeIn>

--- a/src/app/tarieven/page.tsx
+++ b/src/app/tarieven/page.tsx
@@ -1,66 +1,78 @@
-import type { Metadata } from "next";
-import Link from "next/link";
+"use client";
 
-export const metadata: Metadata = {
-  title: "Tarieven",
-  description:
-    "Bekijk onze prijzen voor mini-camping, chambres d'hôtes en table d'hôtes bij Les Deux Chevaux.",
-};
+import Link from "next/link";
+import { useTranslation } from "@/i18n";
 
 export default function Tarieven() {
+  const { t } = useTranslation();
+
   return (
     <>
       {/* Header */}
       <section className="py-16 bg-amber-800 text-white">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-center">
-          <h1 className="text-4xl font-bold mb-4">Onze Tarieven</h1>
-          <p className="text-xl text-amber-100">
-            Prijzen voor camping, kamers en maaltijden
-          </p>
+          <h1 className="text-4xl font-bold mb-4">{t.rates.heroTitle}</h1>
+          <p className="text-xl text-amber-100">{t.rates.heroSubtitle}</p>
         </div>
       </section>
 
       {/* Camping Rates */}
       <section className="py-16 bg-white">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl font-bold text-amber-900 mb-8">Camping</h2>
+          <h2 className="text-3xl font-bold text-amber-900 mb-8">
+            {t.rates.campingTitle}
+          </h2>
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
                 <tr className="bg-amber-100">
                   <th className="px-6 py-4 text-left text-amber-900 font-semibold">
-                    Omschrijving
+                    {t.rates.description}
                   </th>
                   <th className="px-6 py-4 text-right text-amber-900 font-semibold">
-                    Prijs
+                    {t.rates.price}
                   </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200">
                 <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4">Plek (2 personen + auto)</td>
-                  <td className="px-6 py-4 text-right font-medium">€17,50</td>
-                </tr>
-                <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4">Extra persoon</td>
-                  <td className="px-6 py-4 text-right font-medium">€2,50</td>
-                </tr>
-                <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4">Elektriciteit</td>
-                  <td className="px-6 py-4 text-right font-medium text-green-600">
-                    Inbegrepen
+                  <td className="px-6 py-4">
+                    {t.rates.campingItems.pitch.description}
                   </td>
-                </tr>
-                <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4">Hond (aangelijnd)</td>
-                  <td className="px-6 py-4 text-right font-medium text-green-600">
-                    Gratis
-                  </td>
-                </tr>
-                <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4">Toeristenbelasting</td>
                   <td className="px-6 py-4 text-right font-medium">
-                    €0,25 p.p./dag
+                    {t.rates.campingItems.pitch.price}
+                  </td>
+                </tr>
+                <tr className="hover:bg-amber-50">
+                  <td className="px-6 py-4">
+                    {t.rates.campingItems.extraPerson.description}
+                  </td>
+                  <td className="px-6 py-4 text-right font-medium">
+                    {t.rates.campingItems.extraPerson.price}
+                  </td>
+                </tr>
+                <tr className="hover:bg-amber-50">
+                  <td className="px-6 py-4">
+                    {t.rates.campingItems.electricity.description}
+                  </td>
+                  <td className="px-6 py-4 text-right font-medium text-green-600">
+                    {t.rates.campingItems.electricity.price}
+                  </td>
+                </tr>
+                <tr className="hover:bg-amber-50">
+                  <td className="px-6 py-4">
+                    {t.rates.campingItems.dog.description}
+                  </td>
+                  <td className="px-6 py-4 text-right font-medium text-green-600">
+                    {t.rates.campingItems.dog.price}
+                  </td>
+                </tr>
+                <tr className="hover:bg-amber-50">
+                  <td className="px-6 py-4">
+                    {t.rates.campingItems.touristTax.description}
+                  </td>
+                  <td className="px-6 py-4 text-right font-medium">
+                    {t.rates.campingItems.touristTax.price}
                   </td>
                 </tr>
               </tbody>
@@ -73,92 +85,110 @@ export default function Tarieven() {
       <section className="py-16 bg-amber-50">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-amber-900 mb-8">
-            Chambres d&apos;Hôtes (Bed & Breakfast)
+            {t.rates.chambresTitle}
           </h2>
           <div className="overflow-x-auto">
             <table className="w-full bg-white rounded-xl shadow-sm">
               <thead>
                 <tr className="bg-amber-100">
                   <th className="px-6 py-4 text-left text-amber-900 font-semibold">
-                    Accommodatie
+                    {t.rates.accommodation}
                   </th>
                   <th className="px-6 py-4 text-right text-amber-900 font-semibold">
-                    Prijs per nacht
+                    {t.rates.pricePerNight}
                   </th>
                   <th className="px-6 py-4 text-left text-amber-900 font-semibold">
-                    Details
+                    {t.rates.details}
                   </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200">
                 <tr className="hover:bg-amber-50">
                   <td className="px-6 py-4 font-medium">
-                    Kamer in hoofdgebouw
+                    {t.rates.chambresItems.mainRoom.name}
                   </td>
                   <td className="px-6 py-4 text-right font-semibold text-amber-700">
-                    €75,00
+                    {t.rates.chambresItems.mainRoom.price}
                   </td>
                   <td className="px-6 py-4 text-gray-600">
-                    2 personen, incl. ontbijt, eigen douche/toilet
+                    {t.rates.chambresItems.mainRoom.details}
                   </td>
                 </tr>
                 <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4 font-medium">La Longère</td>
+                  <td className="px-6 py-4 font-medium">
+                    {t.rates.chambresItems.longere.name}
+                  </td>
                   <td className="px-6 py-4 text-right font-semibold text-amber-700">
-                    €80,00
+                    {t.rates.chambresItems.longere.price}
                   </td>
                   <td className="px-6 py-4 text-gray-600">
-                    2 personen, incl. ontbijt, eigen badkamer
+                    {t.rates.chambresItems.longere.details}
                   </td>
                 </tr>
                 <tr className="hover:bg-amber-50">
                   <td className="px-6 py-4 text-gray-500 pl-10">
-                    + Extra persoon
+                    {t.rates.chambresItems.extraPerson.name}
                   </td>
-                  <td className="px-6 py-4 text-right font-medium">€30,00</td>
-                  <td className="px-6 py-4 text-gray-600">Per extra persoon</td>
-                </tr>
-                <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4 font-medium">Chez Marco</td>
-                  <td className="px-6 py-4 text-right font-semibold text-amber-700">
-                    €80,00
+                  <td className="px-6 py-4 text-right font-medium">
+                    {t.rates.chambresItems.extraPerson.price}
                   </td>
                   <td className="px-6 py-4 text-gray-600">
-                    2 personen, incl. ontbijt, eigen badkamer
+                    {t.rates.chambresItems.extraPerson.details}
+                  </td>
+                </tr>
+                <tr className="hover:bg-amber-50">
+                  <td className="px-6 py-4 font-medium">
+                    {t.rates.chambresItems.chezMarco.name}
+                  </td>
+                  <td className="px-6 py-4 text-right font-semibold text-amber-700">
+                    {t.rates.chambresItems.chezMarco.price}
+                  </td>
+                  <td className="px-6 py-4 text-gray-600">
+                    {t.rates.chambresItems.chezMarco.details}
                   </td>
                 </tr>
                 <tr className="hover:bg-amber-50">
                   <td className="px-6 py-4 text-gray-500 pl-10">
-                    + Extra persoon
+                    {t.rates.chambresItems.extraPerson.name}
                   </td>
-                  <td className="px-6 py-4 text-right font-medium">€30,00</td>
-                  <td className="px-6 py-4 text-gray-600">Per extra persoon</td>
-                </tr>
-                <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4 font-medium">Kleine caravan</td>
-                  <td className="px-6 py-4 text-right font-semibold text-amber-700">
-                    €70,00 / €65,00
+                  <td className="px-6 py-4 text-right font-medium">
+                    {t.rates.chambresItems.extraPerson.price}
                   </td>
                   <td className="px-6 py-4 text-gray-600">
-                    Met/zonder ontbijt (min. 2 nachten)
+                    {t.rates.chambresItems.extraPerson.details}
                   </td>
                 </tr>
                 <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4 font-medium">Luxe tent</td>
+                  <td className="px-6 py-4 font-medium">
+                    {t.rates.chambresItems.smallCaravan.name}
+                  </td>
                   <td className="px-6 py-4 text-right font-semibold text-amber-700">
-                    €70,00 / €65,00
+                    {t.rates.chambresItems.smallCaravan.price}
                   </td>
                   <td className="px-6 py-4 text-gray-600">
-                    Met/zonder ontbijt (min. 2 nachten)
+                    {t.rates.chambresItems.smallCaravan.details}
                   </td>
                 </tr>
                 <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4 font-medium">La Bergerie (huisje)</td>
+                  <td className="px-6 py-4 font-medium">
+                    {t.rates.chambresItems.luxuryTent.name}
+                  </td>
                   <td className="px-6 py-4 text-right font-semibold text-amber-700">
-                    €70,00 / €65,00
+                    {t.rates.chambresItems.luxuryTent.price}
                   </td>
                   <td className="px-6 py-4 text-gray-600">
-                    Met/zonder ontbijt
+                    {t.rates.chambresItems.luxuryTent.details}
+                  </td>
+                </tr>
+                <tr className="hover:bg-amber-50">
+                  <td className="px-6 py-4 font-medium">
+                    {t.rates.chambresItems.bergerie.name}
+                  </td>
+                  <td className="px-6 py-4 text-right font-semibold text-amber-700">
+                    {t.rates.chambresItems.bergerie.price}
+                  </td>
+                  <td className="px-6 py-4 text-gray-600">
+                    {t.rates.chambresItems.bergerie.details}
                   </td>
                 </tr>
               </tbody>
@@ -171,43 +201,51 @@ export default function Tarieven() {
       <section className="py-16 bg-white">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-amber-900 mb-8">
-            Table d&apos;Hôtes (Maaltijden)
+            {t.rates.tableTitle}
           </h2>
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
                 <tr className="bg-amber-100">
                   <th className="px-6 py-4 text-left text-amber-900 font-semibold">
-                    Maaltijd
+                    {t.rates.meal}
                   </th>
                   <th className="px-6 py-4 text-right text-amber-900 font-semibold">
-                    Prijs
+                    {t.rates.price}
                   </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200">
                 <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4">Driegangen diner met koffie</td>
+                  <td className="px-6 py-4">
+                    {t.rates.tableItems.dinner.description}
+                  </td>
                   <td className="px-6 py-4 text-right font-semibold text-amber-700">
-                    €20,00 p.p.
+                    {t.rates.tableItems.dinner.price}
                   </td>
                 </tr>
                 <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4">Drankjes bij diner</td>
+                  <td className="px-6 py-4">
+                    {t.rates.tableItems.drinks.description}
+                  </td>
                   <td className="px-6 py-4 text-right font-medium">
-                    €2,00 per stuk
+                    {t.rates.tableItems.drinks.price}
                   </td>
                 </tr>
                 <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4">Lunch</td>
+                  <td className="px-6 py-4">
+                    {t.rates.tableItems.lunch.description}
+                  </td>
                   <td className="px-6 py-4 text-right font-semibold text-amber-700">
-                    €7,50 p.p.
+                    {t.rates.tableItems.lunch.price}
                   </td>
                 </tr>
                 <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4">Ontbijt (los)</td>
+                  <td className="px-6 py-4">
+                    {t.rates.tableItems.breakfast.description}
+                  </td>
                   <td className="px-6 py-4 text-right font-semibold text-amber-700">
-                    €6,50 p.p.
+                    {t.rates.tableItems.breakfast.price}
                   </td>
                 </tr>
               </tbody>
@@ -219,16 +257,15 @@ export default function Tarieven() {
       {/* CTA */}
       <section className="py-16 bg-amber-800 text-white">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="text-3xl font-bold mb-6">Interesse?</h2>
+          <h2 className="text-3xl font-bold mb-6">{t.common.interested}</h2>
           <p className="text-xl text-amber-100 mb-8 max-w-2xl mx-auto">
-            Neem contact met ons op voor meer informatie of om een reservering
-            te maken.
+            {t.common.contactUs}
           </p>
           <Link
             href="/contact"
             className="inline-block px-8 py-3 bg-white text-amber-800 font-semibold rounded-lg hover:bg-amber-50 transition-colors"
           >
-            Neem contact op
+            {t.common.contact}
           </Link>
         </div>
       </section>

--- a/src/app/waar-zijn-wij/page.tsx
+++ b/src/app/waar-zijn-wij/page.tsx
@@ -1,20 +1,18 @@
+"use client";
+
 import Image from "next/image";
-import type { Metadata } from "next";
 import Hero from "@/components/Hero";
 import { getImagePath } from "@/lib/config";
-
-export const metadata: Metadata = {
-  title: "Waar zitten wij?",
-  description:
-    "Les Deux Chevaux ligt in het pittoreske dorpje Nades, Auvergne, Frankrijk - ongeveer 60 km ten noorden van Clermont-Ferrand.",
-};
+import { useTranslation } from "@/i18n";
 
 export default function WaarZijnWij() {
+  const { t } = useTranslation();
+
   return (
     <>
       <Hero
-        title="Waar zitten wij?"
-        subtitle="Onze locatie in het hart van de Auvergne"
+        title={t.nav.whereAreWe}
+        subtitle={t.whereAreWe.heroSubtitle}
         image="/uploads/2020/07/landschap-panorama-1024x405.jpg"
       />
 
@@ -23,52 +21,42 @@ export default function WaarZijnWij() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
             <div className="prose max-w-none">
               <h2 className="text-2xl font-bold text-amber-900 mb-6">
-                Nades, Auvergne
+                {t.whereAreWe.title}
               </h2>
-              <p className="text-lg text-gray-600 mb-4">
-                Wij bevinden ons in het pittoreske dorpje{" "}
-                <strong>Nades</strong> (spreek uit: &quot;nade&quot;), gelegen
-                in het uiterste zuiden van het departement Allier, één van de
-                vier departementen in de regio Auvergne.
-              </p>
+              <p className="text-lg text-gray-600 mb-4">{t.whereAreWe.text}</p>
 
               <div className="bg-amber-50 p-6 rounded-xl my-8">
                 <h3 className="text-xl font-semibold text-amber-800 mb-4">
-                  Adres
+                  {t.whereAreWe.addressTitle}
                 </h3>
                 <address className="not-italic text-gray-700">
                   <strong>7 Impasse de la Tranquillité</strong>
                   <br />
                   Nades, Allier
                   <br />
-                  Auvergne, Frankrijk
+                  Auvergne, France
                 </address>
                 <p className="mt-4 text-sm text-gray-600">
-                  Dit adres wordt herkend door zowel Google Maps als TomTom
-                  navigatiesystemen.
+                  {t.whereAreWe.addressNote}
                 </p>
               </div>
 
               <h3 className="text-xl font-semibold text-amber-800 mb-4">
-                Afstanden
+                {t.whereAreWe.distances}
               </h3>
               <ul className="space-y-2 text-gray-600">
-                <li>
-                  🚗 Ongeveer <strong>60 km</strong> ten noorden van
-                  Clermont-Ferrand
-                </li>
-                <li>
-                  🚗 Ongeveer <strong>750 km</strong> van Zierikzee, Nederland
-                  (halverwege de zuidelijke route)
-                </li>
+                <li>🚗 {t.whereAreWe.distance1}</li>
+                <li>🚗 {t.whereAreWe.distance2}</li>
               </ul>
             </div>
 
             <div className="space-y-6">
               <div className="relative h-64 rounded-xl overflow-hidden shadow-lg">
                 <Image
-                  src={getImagePath("/uploads/2020/07/landschap-panorama-1024x405.jpg")}
-                  alt="Panorama van het landschap"
+                  src={getImagePath(
+                    "/uploads/2020/07/landschap-panorama-1024x405.jpg"
+                  )}
+                  alt="Panorama"
                   fill
                   className="object-cover"
                   sizes="(max-width: 1024px) 100vw, 50vw"
@@ -78,7 +66,7 @@ export default function WaarZijnWij() {
               {/* Map placeholder */}
               <div className="bg-gray-100 rounded-xl p-8 text-center">
                 <h3 className="text-lg font-semibold text-gray-700 mb-4">
-                  Routebeschrijving
+                  {t.whereAreWe.directions}
                 </h3>
                 <a
                   href="https://www.google.com/maps/search/?api=1&query=7+Impasse+de+la+Tranquillité+Nades+France"
@@ -86,38 +74,9 @@ export default function WaarZijnWij() {
                   rel="noopener noreferrer"
                   className="inline-block px-6 py-3 bg-amber-600 text-white font-semibold rounded-lg hover:bg-amber-700 transition-colors"
                 >
-                  Bekijk op Google Maps
+                  {t.common.viewOnGoogleMaps}
                 </a>
               </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* French version */}
-      <section className="py-16 bg-amber-50">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="max-w-3xl">
-            <h2 className="text-2xl font-bold text-amber-900 mb-6">
-              Où sommes-nous?
-            </h2>
-            <p className="text-lg text-gray-600 mb-4">
-              Nous nous trouvons dans le pittoresque village de{" "}
-              <strong>Nades</strong> (prononcé &quot;nade&quot;), situé à
-              l&apos;extrême sud du département de l&apos;Allier, l&apos;un des
-              quatre départements de la région Auvergne.
-            </p>
-            <div className="bg-white p-6 rounded-xl">
-              <h3 className="text-xl font-semibold text-amber-800 mb-4">
-                Adresse
-              </h3>
-              <address className="not-italic text-gray-700">
-                <strong>7 Impasse de la Tranquillité</strong>
-                <br />
-                Nades, Allier
-                <br />
-                Auvergne, France
-              </address>
             </div>
           </div>
         </div>

--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -1,37 +1,10 @@
+"use client";
+
 import Image from "next/image";
-import type { Metadata } from "next";
 import Hero from "@/components/Hero";
 import ImageGallery from "@/components/ImageGallery";
 import { getImagePath } from "@/lib/config";
-
-export const metadata: Metadata = {
-  title: "Wat te verwachten?",
-  description:
-    "Ontdek onze accommodaties: mini-camping, chambres d'hôtes en La Bergerie. Allemaal met warme gastvrijheid.",
-};
-
-const rooms = [
-  {
-    name: "Rode Kamer",
-    capacity: "2 personen",
-    description: "Comfortabel en sfeervol ingericht",
-  },
-  {
-    name: "Groene Kamer",
-    capacity: "2 personen",
-    description: "Met uitzicht op de tuin",
-  },
-  {
-    name: "Blauwe Kamer",
-    capacity: "2-3 personen",
-    description: "Ruim en licht",
-  },
-  {
-    name: "Familie/Vrienden Kamers",
-    capacity: "Tot 7 personen",
-    description: "Perfect voor groepen",
-  },
-];
+import { useTranslation } from "@/i18n";
 
 const accommodationImages = [
   {
@@ -44,11 +17,36 @@ const accommodationImages = [
 ];
 
 export default function WatTeVerwachten() {
+  const { t } = useTranslation();
+
+  const rooms = [
+    {
+      name: t.whatToExpect.rooms.red.name,
+      capacity: t.whatToExpect.rooms.red.capacity,
+      description: t.whatToExpect.rooms.red.description,
+    },
+    {
+      name: t.whatToExpect.rooms.green.name,
+      capacity: t.whatToExpect.rooms.green.capacity,
+      description: t.whatToExpect.rooms.green.description,
+    },
+    {
+      name: t.whatToExpect.rooms.blue.name,
+      capacity: t.whatToExpect.rooms.blue.capacity,
+      description: t.whatToExpect.rooms.blue.description,
+    },
+    {
+      name: t.whatToExpect.rooms.family.name,
+      capacity: t.whatToExpect.rooms.family.capacity,
+      description: t.whatToExpect.rooms.family.description,
+    },
+  ];
+
   return (
     <>
       <Hero
-        title="Wat kun je bij ons verwachten?"
-        subtitle="Onze accommodaties en faciliteiten"
+        title={t.whatToExpect.heroTitle}
+        subtitle={t.whatToExpect.heroSubtitle}
         image="/uploads/2016/09/Les-2CV-3-copy-1024x683.jpg"
       />
 
@@ -56,11 +54,7 @@ export default function WatTeVerwachten() {
       <section className="py-16 bg-white">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="max-w-3xl mx-auto text-center">
-            <p className="text-xl text-gray-600">
-              Bij Les Deux Chevaux bieden we verschillende verblijfsmogelijkheden,
-              van kamperen tot luxe kamers, allemaal met de warme gastvrijheid
-              die u van ons mag verwachten.
-            </p>
+            <p className="text-xl text-gray-600">{t.whatToExpect.intro}</p>
           </div>
         </div>
       </section>
@@ -69,20 +63,15 @@ export default function WatTeVerwachten() {
       <section className="py-16 bg-amber-50">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-amber-900 text-center mb-12">
-            Chambres d&apos;Hôtes
+            {t.whatToExpect.chambresTitle}
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-12">
             {rooms.map((room) => (
-              <div
-                key={room.name}
-                className="bg-white p-6 rounded-xl shadow-sm"
-              >
+              <div key={room.name} className="bg-white p-6 rounded-xl shadow-sm">
                 <h3 className="text-xl font-semibold text-amber-800 mb-2">
                   {room.name}
                 </h3>
-                <p className="text-amber-600 font-medium mb-2">
-                  {room.capacity}
-                </p>
+                <p className="text-amber-600 font-medium mb-2">{room.capacity}</p>
                 <p className="text-gray-600">{room.description}</p>
               </div>
             ))}
@@ -90,7 +79,7 @@ export default function WatTeVerwachten() {
           <div className="relative h-80 rounded-xl overflow-hidden shadow-lg max-w-3xl mx-auto">
             <Image
               src={getImagePath("/uploads/2016/09/Les-2CV-3-copy-1024x683.jpg")}
-              alt="Groene Kamer"
+              alt="Chambre"
               fill
               className="object-cover"
               sizes="(max-width: 1024px) 100vw, 768px"
@@ -105,28 +94,27 @@ export default function WatTeVerwachten() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
             <div>
               <h2 className="text-3xl font-bold text-amber-900 mb-6">
-                Mini-Camping
+                {t.whatToExpect.campingTitle}
               </h2>
               <p className="text-lg text-gray-600 mb-4">
-                Wij hebben <strong>6 plekken</strong> voor tenten en caravans,
-                met een ontspannen sfeer en alle nodige faciliteiten.
+                {t.whatToExpect.campingText}
               </p>
               <ul className="space-y-3 text-gray-600">
                 <li className="flex items-start gap-2">
                   <span className="text-amber-600">✓</span>
-                  Elektriciteit inbegrepen
+                  {t.whatToExpect.campingFeatures.electricity}
                 </li>
                 <li className="flex items-start gap-2">
                   <span className="text-amber-600">✓</span>
-                  Honden welkom (aangelijnd)
+                  {t.whatToExpect.campingFeatures.dogs}
                 </li>
                 <li className="flex items-start gap-2">
                   <span className="text-amber-600">✓</span>
-                  Rustige, groene omgeving
+                  {t.whatToExpect.campingFeatures.quiet}
                 </li>
                 <li className="flex items-start gap-2">
                   <span className="text-amber-600">✓</span>
-                  Gedeelde sanitaire voorzieningen
+                  {t.whatToExpect.campingFeatures.sanitary}
                 </li>
               </ul>
             </div>
@@ -147,31 +135,25 @@ export default function WatTeVerwachten() {
       <section className="py-16 bg-amber-50">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-amber-900 text-center mb-12">
-            Aanvullende Verblijfsopties
+            {t.whatToExpect.additionalTitle}
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             <div className="bg-white p-8 rounded-xl shadow-sm">
               <h3 className="text-2xl font-semibold text-amber-800 mb-4">
-                Uitgeruste Caravan
+                {t.whatToExpect.caravan.title}
               </h3>
-              <p className="text-gray-600 mb-4">
-                Voor wie wil kamperen zonder eigen spullen. Volledig ingericht
-                en klaar voor gebruik.
-              </p>
+              <p className="text-gray-600 mb-4">{t.whatToExpect.caravan.text}</p>
               <p className="text-amber-600 font-medium">
-                Minimaal 2 nachten verblijf
+                {t.whatToExpect.caravan.note}
               </p>
             </div>
             <div className="bg-white p-8 rounded-xl shadow-sm">
               <h3 className="text-2xl font-semibold text-amber-800 mb-4">
-                La Bergerie
+                {t.whatToExpect.bergerie.title}
               </h3>
-              <p className="text-gray-600 mb-4">
-                Een romantisch huisje voor koppels. Privé en rustig gelegen op
-                ons terrein.
-              </p>
+              <p className="text-gray-600 mb-4">{t.whatToExpect.bergerie.text}</p>
               <p className="text-amber-600 font-medium">
-                Perfect voor een romantisch uitje
+                {t.whatToExpect.bergerie.note}
               </p>
             </div>
           </div>
@@ -184,25 +166,23 @@ export default function WatTeVerwachten() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
             <div className="lg:order-last">
               <h2 className="text-3xl font-bold text-amber-900 mb-6">
-                Table d&apos;Hôtes
+                {t.whatToExpect.tableTitle}
               </h2>
               <p className="text-lg text-gray-600 mb-4">
-                Onze table d&apos;hôtes biedt heerlijke, vers bereide maaltijden.
-                Geniet samen met andere gasten van een authentieke Franse
-                eetervaring.
+                {t.whatToExpect.tableText}
               </p>
               <ul className="space-y-3 text-gray-600">
                 <li className="flex items-start gap-2">
                   <span className="text-amber-600">✓</span>
-                  Driegangen diner met koffie
+                  {t.whatToExpect.tableFeatures.dinner}
                 </li>
                 <li className="flex items-start gap-2">
                   <span className="text-amber-600">✓</span>
-                  Verse, lokale ingrediënten
+                  {t.whatToExpect.tableFeatures.fresh}
                 </li>
                 <li className="flex items-start gap-2">
                   <span className="text-amber-600">✓</span>
-                  Gezellige sfeer met andere gasten
+                  {t.whatToExpect.tableFeatures.atmosphere}
                 </li>
               </ul>
             </div>
@@ -223,7 +203,7 @@ export default function WatTeVerwachten() {
       <section className="py-16 bg-amber-50">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-amber-900 text-center mb-12">
-            Impressies
+            {t.whatToExpect.impressions}
           </h2>
           <ImageGallery images={accommodationImages} />
         </div>

--- a/src/app/wie-zijn-wij/page.tsx
+++ b/src/app/wie-zijn-wij/page.tsx
@@ -1,20 +1,18 @@
+"use client";
+
 import Image from "next/image";
-import type { Metadata } from "next";
 import Hero from "@/components/Hero";
 import { getImagePath } from "@/lib/config";
-
-export const metadata: Metadata = {
-  title: "Wie zijn wij?",
-  description:
-    "Maak kennis met Yvonne en Rob, de eigenaren van Les Deux Chevaux in de Auvergne.",
-};
+import { useTranslation } from "@/i18n";
 
 export default function WieZijnWij() {
+  const { t } = useTranslation();
+
   return (
     <>
       <Hero
-        title="Wie zijn wij?"
-        subtitle="Maak kennis met Yvonne en Rob"
+        title={t.nav.whoAreWe}
+        subtitle={t.whoAreWe.heroSubtitle}
         image="/uploads/2021/09/rob-en-yvonne-1.jpg"
       />
 
@@ -23,22 +21,11 @@ export default function WieZijnWij() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-start">
             <div className="prose max-w-none">
               <h2 className="text-2xl font-bold text-amber-900 mb-6">
-                Yvonne van de Velde & Rob Nijholt
+                {t.whoAreWe.title}
               </h2>
-              <p className="text-lg text-gray-600 mb-4">
-                Wij zijn eind juni 2013 vanuit Zierikzee, Nederland, naar de
-                Auvergne in Frankrijk verhuisd om ons droomleven te beginnen.
-              </p>
-              <p className="text-lg text-gray-600 mb-4">
-                Nu runnen wij met veel plezier onze mini-camping en chambres
-                d&apos;hôtes. We heten u van harte welkom om de rust en schoonheid
-                van de Auvergne met ons te delen.
-              </p>
-              <p className="text-lg text-gray-600">
-                Of u nu komt kamperen, overnachten in een van onze kamers, of
-                genieten van onze table d&apos;hôtes - wij zorgen ervoor dat u
-                zich thuis voelt.
-              </p>
+              <p className="text-lg text-gray-600 mb-4">{t.whoAreWe.text1}</p>
+              <p className="text-lg text-gray-600 mb-4">{t.whoAreWe.text2}</p>
+              <p className="text-lg text-gray-600">{t.whoAreWe.text3}</p>
             </div>
             <div className="relative h-96 rounded-xl overflow-hidden shadow-lg">
               <Image
@@ -64,36 +51,10 @@ export default function WieZijnWij() {
             </div>
             <div>
               <h2 className="text-2xl font-bold text-amber-900 mb-6">
-                Onze trouwe vriend Jip
+                {t.whoAreWe.jipTitle}
               </h2>
-              <p className="text-lg text-gray-600">
-                En dan is er nog <strong>Jip</strong>, ons trouwe maatje die u
-                graag begroet bij aankomst! Jip is altijd blij om nieuwe gasten
-                te ontmoeten en zorgt voor een warm welkom.
-              </p>
+              <p className="text-lg text-gray-600">{t.whoAreWe.jipText}</p>
             </div>
-          </div>
-        </div>
-      </section>
-
-      {/* French version */}
-      <section className="py-16 bg-amber-50">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="max-w-3xl">
-            <h2 className="text-2xl font-bold text-amber-900 mb-6">
-              Qui sommes-nous?
-            </h2>
-            <p className="text-lg text-gray-600 mb-4">
-              <strong>Les Deux Chevaux</strong> est géré par{" "}
-              <strong>Yvonne van de Velde</strong> et{" "}
-              <strong>Rob Nijholt</strong>.
-            </p>
-            <p className="text-lg text-gray-600">
-              Fin juin 2013, nous avons quitté Zierikzee, aux Pays-Bas, pour
-              nous installer en Auvergne, en France, afin de réaliser notre
-              rêve. Aujourd&apos;hui, nous gérons avec plaisir notre mini-camping
-              et nos chambres d&apos;hôtes.
-            </p>
           </div>
         </div>
       </section>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,13 +1,18 @@
+"use client";
+
 import Link from "next/link";
+import { useTranslation } from "@/i18n";
 
 export default function Footer() {
+  const { t } = useTranslation();
+
   return (
     <footer className="bg-[#5C5840] text-white">
       <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {/* Contact Info */}
           <div>
-            <h3 className="text-lg font-semibold mb-4">Contact</h3>
+            <h3 className="text-lg font-semibold mb-4">{t.footer.contact}</h3>
             <div className="space-y-2 text-[#D4C9A8]">
               <p>
                 <a
@@ -24,35 +29,35 @@ export default function Footer() {
 
           {/* Address */}
           <div>
-            <h3 className="text-lg font-semibold mb-4">Adres</h3>
+            <h3 className="text-lg font-semibold mb-4">{t.footer.address}</h3>
             <div className="text-[#D4C9A8]">
               <p>7 Impasse de la Tranquillité</p>
               <p>Nades, Allier</p>
-              <p>Auvergne, Frankrijk</p>
+              <p>Auvergne, France</p>
             </div>
           </div>
 
           {/* Quick Links */}
           <div>
-            <h3 className="text-lg font-semibold mb-4">Navigatie</h3>
+            <h3 className="text-lg font-semibold mb-4">{t.footer.navigation}</h3>
             <div className="space-y-2">
               <Link
                 href="/tarieven"
                 className="block text-[#D4C9A8] hover:text-white transition-colors"
               >
-                Tarieven
+                {t.footer.rates}
               </Link>
               <Link
                 href="/contact"
                 className="block text-[#D4C9A8] hover:text-white transition-colors"
               >
-                Contact
+                {t.nav.contact}
               </Link>
               <Link
                 href="/de-streek"
                 className="block text-[#D4C9A8] hover:text-white transition-colors"
               >
-                De streek
+                {t.footer.theRegion}
               </Link>
             </div>
           </div>
@@ -60,8 +65,8 @@ export default function Footer() {
 
         <div className="mt-8 pt-8 border-t border-[#4A4635] text-center text-[#D4C9A8]">
           <p>
-            &copy; {new Date().getFullYear()} Les Deux Chevaux. Alle rechten
-            voorbehouden.
+            &copy; {new Date().getFullYear()} Les Deux Chevaux.{" "}
+            {t.footer.allRightsReserved}.
           </p>
         </div>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,19 +4,22 @@ import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
 import { getImagePath } from "@/lib/config";
-
-const navigation = [
-  { title: "Home", href: "/" },
-  { title: "Wie zijn wij?", href: "/wie-zijn-wij" },
-  { title: "Waar zitten wij?", href: "/waar-zijn-wij" },
-  { title: "De streek", href: "/de-streek" },
-  { title: "Wat te verwachten?", href: "/wat-te-verwachten" },
-  { title: "Tarieven", href: "/tarieven" },
-  { title: "Contact", href: "/contact" },
-];
+import { useTranslation } from "@/i18n";
+import LanguageToggle from "./LanguageToggle";
 
 export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const { t } = useTranslation();
+
+  const navigation = [
+    { title: t.nav.home, href: "/" },
+    { title: t.nav.whoAreWe, href: "/wie-zijn-wij" },
+    { title: t.nav.whereAreWe, href: "/waar-zijn-wij" },
+    { title: t.nav.theRegion, href: "/de-streek" },
+    { title: t.nav.whatToExpect, href: "/wat-te-verwachten" },
+    { title: t.nav.rates, href: "/tarieven" },
+    { title: t.nav.contact, href: "/contact" },
+  ];
 
   return (
     <header className="sticky top-0 z-50 bg-[#837F5A] shadow-md">
@@ -37,7 +40,7 @@ export default function Header() {
           </div>
 
           {/* Desktop Navigation */}
-          <div className="hidden lg:flex lg:items-center lg:gap-8">
+          <div className="hidden lg:flex lg:items-center lg:gap-6">
             {navigation.map((item) => (
               <Link
                 key={item.href}
@@ -47,10 +50,12 @@ export default function Header() {
                 {item.title}
               </Link>
             ))}
+            <LanguageToggle />
           </div>
 
           {/* Mobile menu button */}
-          <div className="lg:hidden">
+          <div className="lg:hidden flex items-center gap-3">
+            <LanguageToggle />
             <button
               type="button"
               onClick={() => setIsMenuOpen(!isMenuOpen)}

--- a/src/components/LanguageToggle.tsx
+++ b/src/components/LanguageToggle.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useTranslation } from "@/i18n";
+
+export default function LanguageToggle() {
+  const { locale, setLocale } = useTranslation();
+
+  const toggleLanguage = () => {
+    setLocale(locale === "nl" ? "fr" : "nl");
+  };
+
+  return (
+    <button
+      onClick={toggleLanguage}
+      className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-[#6E6A4A] hover:bg-[#5C5840] transition-colors text-sm font-medium"
+      aria-label={
+        locale === "nl" ? "Changer en français" : "Overschakelen naar Nederlands"
+      }
+    >
+      <span
+        className={`transition-opacity ${locale === "nl" ? "text-white" : "text-[#D4C9A8]"}`}
+      >
+        NL
+      </span>
+      <span className="text-[#A09B7D]">/</span>
+      <span
+        className={`transition-opacity ${locale === "fr" ? "text-white" : "text-[#D4C9A8]"}`}
+      >
+        FR
+      </span>
+    </button>
+  );
+}

--- a/src/i18n/LanguageContext.tsx
+++ b/src/i18n/LanguageContext.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  ReactNode,
+} from "react";
+import type { Locale, Translations } from "./types";
+import nl from "./locales/nl.json";
+import fr from "./locales/fr.json";
+
+const translations: Record<Locale, Translations> = {
+  nl: nl as Translations,
+  fr: fr as Translations,
+};
+
+interface LanguageContextType {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: Translations;
+}
+
+const LanguageContext = createContext<LanguageContextType | undefined>(
+  undefined
+);
+
+const STORAGE_KEY = "lesdeuxchevaux-language";
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocaleState] = useState<Locale>("nl");
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as Locale | null;
+    if (stored && (stored === "nl" || stored === "fr")) {
+      setLocaleState(stored);
+      document.documentElement.lang = stored;
+    }
+  }, []);
+
+  const setLocale = (newLocale: Locale) => {
+    setLocaleState(newLocale);
+    localStorage.setItem(STORAGE_KEY, newLocale);
+    document.documentElement.lang = newLocale;
+  };
+
+  const value: LanguageContextType = {
+    locale,
+    setLocale,
+    t: translations[locale],
+  };
+
+  return (
+    <LanguageContext.Provider value={value}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error("useLanguage must be used within a LanguageProvider");
+  }
+  return context;
+}
+
+export function useTranslation() {
+  const { t, locale, setLocale } = useLanguage();
+  return { t, locale, setLocale };
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,2 @@
+export { LanguageProvider, useLanguage, useTranslation } from "./LanguageContext";
+export type { Locale, Translations } from "./types";

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1,0 +1,302 @@
+{
+  "nav": {
+    "home": "Accueil",
+    "whoAreWe": "Qui sommes-nous ?",
+    "whereAreWe": "Où sommes-nous ?",
+    "theRegion": "La région",
+    "whatToExpect": "À quoi s'attendre ?",
+    "rates": "Tarifs",
+    "contact": "Contact"
+  },
+  "common": {
+    "readMore": "En savoir plus",
+    "contact": "Contactez-nous",
+    "viewRates": "Voir les tarifs",
+    "openInGoogleMaps": "Ouvrir dans Google Maps",
+    "allRightsReserved": "Tous droits réservés",
+    "address": "Adresse",
+    "navigation": "Navigation",
+    "phone": "Téléphone",
+    "email": "E-mail",
+    "interested": "Intéressé(e) ?",
+    "contactUs": "Contactez-nous pour plus d'informations ou pour faire une réservation.",
+    "location": "Localisation",
+    "viewOnGoogleMaps": "Voir sur Google Maps",
+    "persons": "personnes",
+    "person": "personne",
+    "perNight": "par nuit",
+    "included": "Inclus",
+    "free": "Gratuit"
+  },
+  "home": {
+    "heroSubtitle": "Mini-camping, chambres d'hôtes et table d'hôtes en Auvergne",
+    "welcomeTitle": "Bienvenue en Auvergne",
+    "welcomeText1": "Bienvenue sur le site de Les Deux Chevaux, un mini-camping convivial, chambres d'hôtes (Bed & Breakfast) et table d'hôtes dans la magnifique Auvergne, France.",
+    "welcomeText2": "Nous, Yvonne et Rob, vous souhaitons la bienvenue dans notre petit coin de paradis au cœur de la France.",
+    "whatWeOffer": "Que proposons-nous ?",
+    "whyTheName": "Pourquoi \"Les Deux Chevaux\" ?",
+    "whyTheNameText1": "Le nom \"Les Deux Chevaux\" fait référence à l'emblématique voiture française, la Citroën 2CV - soit \"deux chevaux\" (deux chevaux-vapeur).",
+    "whyTheNameText2": "Cette voiture symbolise la vie détendue et authentique de la campagne française que nous souhaitons offrir à nos hôtes.",
+    "impressions": "Impressions",
+    "readyForStay": "Prêt pour votre séjour en Auvergne ?",
+    "ctaText": "Contactez-nous pour plus d'informations ou pour faire une réservation.",
+    "highlights": {
+      "camping": {
+        "title": "Mini-Camping",
+        "description": "6 emplacements spacieux pour tente ou caravane dans une ambiance détendue"
+      },
+      "chambres": {
+        "title": "Chambres d'Hôtes",
+        "description": "Chambres confortables avec délicieux petit-déjeuner français"
+      },
+      "table": {
+        "title": "Table d'Hôtes",
+        "description": "Savourez d'authentiques repas français"
+      }
+    }
+  },
+  "whoAreWe": {
+    "heroSubtitle": "Faites connaissance avec Yvonne et Rob",
+    "title": "Yvonne van de Velde & Rob Nijholt",
+    "text1": "Fin juin 2013, nous avons quitté Zierikzee, aux Pays-Bas, pour nous installer en Auvergne, en France, afin de réaliser notre rêve.",
+    "text2": "Aujourd'hui, nous gérons avec plaisir notre mini-camping et nos chambres d'hôtes. Nous vous souhaitons la bienvenue pour partager avec nous le calme et la beauté de l'Auvergne.",
+    "text3": "Que vous veniez camper, passer la nuit dans l'une de nos chambres ou profiter de notre table d'hôtes - nous veillons à ce que vous vous sentiez chez vous.",
+    "jipTitle": "Notre fidèle ami Jip",
+    "jipText": "Et puis il y a Jip, notre fidèle compagnon qui vous accueillera avec plaisir à votre arrivée ! Jip est toujours content de rencontrer de nouveaux hôtes et vous réserve un accueil chaleureux."
+  },
+  "whereAreWe": {
+    "heroSubtitle": "Notre emplacement au cœur de l'Auvergne",
+    "title": "Nades, Auvergne",
+    "text": "Nous nous trouvons dans le pittoresque village de Nades (prononcé \"nade\"), situé à l'extrême sud du département de l'Allier, l'un des quatre départements de la région Auvergne.",
+    "addressTitle": "Adresse",
+    "addressNote": "Cette adresse est reconnue par Google Maps et les systèmes de navigation TomTom.",
+    "distances": "Distances",
+    "distance1": "Environ 60 km au nord de Clermont-Ferrand",
+    "distance2": "Environ 750 km de Zierikzee, Pays-Bas (à mi-chemin de la route sud)",
+    "directions": "Itinéraire"
+  },
+  "theRegion": {
+    "heroTitle": "Que propose la région ?",
+    "heroSubtitle": "Découvrez la magnifique Auvergne",
+    "intro1": "L'Auvergne offre beauté et activités toute l'année pour tous. C'est un endroit où vous pouvez vraiment vous ressourcer.",
+    "intro2": "Laissez la technologie derrière vous et profitez d'une remise à zéro complète dans la nature.",
+    "outdoorActivities": "Activités de plein air",
+    "attractionsTitle": "Attractions dans un rayon de 60 km",
+    "winterTitle": "Aussi en hiver",
+    "winterText1": "L'Auvergne est également magnifique en hiver, avec des possibilités de randonnées hivernales et le plaisir du calme.",
+    "winterText2": "Profitez des paysages enneigés et de l'ambiance chaleureuse près de la cheminée.",
+    "impressions": "Impressions de la région",
+    "activities": {
+      "hiking": {
+        "title": "Randonnée",
+        "description": "De nombreux sentiers de différents niveaux de difficulté à travers le magnifique paysage."
+      },
+      "mountainBiking": {
+        "title": "VTT",
+        "description": "Un paradis pour les amateurs de VTT avec des parcours stimulants."
+      },
+      "cycling": {
+        "title": "Cyclisme",
+        "description": "Découvrez la région à vélo via des routes pittoresques."
+      },
+      "fishing": {
+        "title": "Pêche",
+        "description": "Pêchez dans la rivière Sioule, riche en espèces de poissons diverses."
+      },
+      "canoeing": {
+        "title": "Canoë",
+        "description": "Naviguez sur la Sioule et profitez de la nature depuis l'eau."
+      },
+      "horseRiding": {
+        "title": "Équitation",
+        "description": "Explorez les environs à cheval ou à dos d'âne."
+      }
+    },
+    "attractions": {
+      "puyDeDome": {
+        "title": "Puy de Dôme",
+        "description": "Volcan emblématique avec une vue imprenable."
+      },
+      "puyDeSancy": {
+        "title": "Puy de Sancy",
+        "description": "Plus haut sommet du Massif Central."
+      },
+      "castles": {
+        "title": "Châteaux et ruines",
+        "description": "Riche patrimoine historique dans les environs."
+      },
+      "vulcania": {
+        "title": "Parc Vulcania",
+        "description": "Parc à thème aventure sur les volcans près de Clermont-Ferrand."
+      },
+      "autoMuseum": {
+        "title": "Musée de l'Auto Bellenave",
+        "description": "Pour les amateurs de voitures classiques."
+      },
+      "fleaMarkets": {
+        "title": "Marchés aux puces",
+        "description": "Marchés conviviaux avec des trouvailles uniques."
+      }
+    }
+  },
+  "whatToExpect": {
+    "heroTitle": "À quoi s'attendre chez nous ?",
+    "heroSubtitle": "Nos hébergements et équipements",
+    "intro": "Chez Les Deux Chevaux, nous proposons différentes options d'hébergement, du camping aux chambres de luxe, le tout avec l'accueil chaleureux que vous pouvez attendre de nous.",
+    "chambresTitle": "Chambres d'Hôtes",
+    "rooms": {
+      "red": {
+        "name": "Chambre Rouge",
+        "capacity": "2 personnes",
+        "description": "Confortable et chaleureusement décorée"
+      },
+      "green": {
+        "name": "Chambre Verte",
+        "capacity": "2 personnes",
+        "description": "Avec vue sur le jardin"
+      },
+      "blue": {
+        "name": "Chambre Bleue",
+        "capacity": "2-3 personnes",
+        "description": "Spacieuse et lumineuse"
+      },
+      "family": {
+        "name": "Chambres Famille/Amis",
+        "capacity": "Jusqu'à 7 personnes",
+        "description": "Parfait pour les groupes"
+      }
+    },
+    "campingTitle": "Mini-Camping",
+    "campingText": "Nous avons 6 emplacements pour tentes et caravanes, dans une ambiance détendue avec tous les équipements nécessaires.",
+    "campingFeatures": {
+      "electricity": "Électricité incluse",
+      "dogs": "Chiens bienvenus (en laisse)",
+      "quiet": "Environnement calme et verdoyant",
+      "sanitary": "Sanitaires partagés"
+    },
+    "additionalTitle": "Options d'hébergement supplémentaires",
+    "caravan": {
+      "title": "Caravane équipée",
+      "text": "Pour ceux qui veulent camper sans leur propre équipement. Entièrement équipée et prête à l'emploi.",
+      "note": "Minimum 2 nuits"
+    },
+    "bergerie": {
+      "title": "La Bergerie",
+      "text": "Un petit cottage romantique pour les couples. Privé et paisiblement situé sur notre terrain.",
+      "note": "Parfait pour une escapade romantique"
+    },
+    "tableTitle": "Table d'Hôtes",
+    "tableText": "Notre table d'hôtes propose de délicieux repas fraîchement préparés. Profitez d'une expérience culinaire française authentique avec d'autres hôtes.",
+    "tableFeatures": {
+      "dinner": "Dîner trois services avec café",
+      "fresh": "Ingrédients frais et locaux",
+      "atmosphere": "Ambiance conviviale avec d'autres hôtes"
+    },
+    "impressions": "Impressions"
+  },
+  "rates": {
+    "heroTitle": "Nos Tarifs",
+    "heroSubtitle": "Prix pour le camping, les chambres et les repas",
+    "campingTitle": "Camping",
+    "description": "Description",
+    "price": "Prix",
+    "campingItems": {
+      "pitch": {
+        "description": "Emplacement (2 personnes + voiture)",
+        "price": "17,50 €"
+      },
+      "extraPerson": {
+        "description": "Personne supplémentaire",
+        "price": "2,50 €"
+      },
+      "electricity": {
+        "description": "Électricité",
+        "price": "Inclus"
+      },
+      "dog": {
+        "description": "Chien (en laisse)",
+        "price": "Gratuit"
+      },
+      "touristTax": {
+        "description": "Taxe de séjour",
+        "price": "0,25 € p.p./jour"
+      }
+    },
+    "chambresTitle": "Chambres d'Hôtes (Bed & Breakfast)",
+    "accommodation": "Hébergement",
+    "pricePerNight": "Prix par nuit",
+    "details": "Détails",
+    "chambresItems": {
+      "mainRoom": {
+        "name": "Chambre dans bâtiment principal",
+        "price": "75,00 €",
+        "details": "2 personnes, petit-déj. incl., douche/WC privés"
+      },
+      "longere": {
+        "name": "La Longère",
+        "price": "80,00 €",
+        "details": "2 personnes, petit-déj. incl., salle de bain privée"
+      },
+      "extraPerson": {
+        "name": "+ Personne supplémentaire",
+        "price": "30,00 €",
+        "details": "Par personne supplémentaire"
+      },
+      "chezMarco": {
+        "name": "Chez Marco",
+        "price": "80,00 €",
+        "details": "2 personnes, petit-déj. incl., salle de bain privée"
+      },
+      "smallCaravan": {
+        "name": "Petite caravane",
+        "price": "70,00 € / 65,00 €",
+        "details": "Avec/sans petit-déjeuner (min. 2 nuits)"
+      },
+      "luxuryTent": {
+        "name": "Tente de luxe",
+        "price": "70,00 € / 65,00 €",
+        "details": "Avec/sans petit-déjeuner (min. 2 nuits)"
+      },
+      "bergerie": {
+        "name": "La Bergerie (cottage)",
+        "price": "70,00 € / 65,00 €",
+        "details": "Avec/sans petit-déjeuner"
+      }
+    },
+    "tableTitle": "Table d'Hôtes (Repas)",
+    "meal": "Repas",
+    "tableItems": {
+      "dinner": {
+        "description": "Dîner trois services avec café",
+        "price": "20,00 € p.p."
+      },
+      "drinks": {
+        "description": "Boissons au dîner",
+        "price": "2,00 € pièce"
+      },
+      "lunch": {
+        "description": "Déjeuner",
+        "price": "7,50 € p.p."
+      },
+      "breakfast": {
+        "description": "Petit-déjeuner (séparé)",
+        "price": "6,50 € p.p."
+      }
+    }
+  },
+  "contact": {
+    "heroSubtitle": "Contactez-nous pour plus d'informations ou une réservation",
+    "contactDetails": "Coordonnées",
+    "phoneYvonne": "Téléphone Yvonne",
+    "phoneRob": "Téléphone Rob",
+    "viewLocationText": "Voir notre emplacement sur Google Maps"
+  },
+  "footer": {
+    "contact": "Contact",
+    "address": "Adresse",
+    "navigation": "Navigation",
+    "allRightsReserved": "Tous droits réservés",
+    "rates": "Tarifs",
+    "theRegion": "La région"
+  }
+}

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1,0 +1,302 @@
+{
+  "nav": {
+    "home": "Home",
+    "whoAreWe": "Wie zijn wij?",
+    "whereAreWe": "Waar zitten wij?",
+    "theRegion": "De streek",
+    "whatToExpect": "Wat te verwachten?",
+    "rates": "Tarieven",
+    "contact": "Contact"
+  },
+  "common": {
+    "readMore": "Lees meer",
+    "contact": "Neem contact op",
+    "viewRates": "Bekijk tarieven",
+    "openInGoogleMaps": "Open in Google Maps",
+    "allRightsReserved": "Alle rechten voorbehouden",
+    "address": "Adres",
+    "navigation": "Navigatie",
+    "phone": "Telefoon",
+    "email": "E-mail",
+    "interested": "Interesse?",
+    "contactUs": "Neem contact met ons op voor meer informatie of om een reservering te maken.",
+    "location": "Locatie",
+    "viewOnGoogleMaps": "Bekijk op Google Maps",
+    "persons": "personen",
+    "person": "persoon",
+    "perNight": "per nacht",
+    "included": "Inbegrepen",
+    "free": "Gratis"
+  },
+  "home": {
+    "heroSubtitle": "Mini-camping, chambres d'hôtes en table d'hôtes in de Auvergne",
+    "welcomeTitle": "Welkom in de Auvergne",
+    "welcomeText1": "Welkom op de website van Les Deux Chevaux, een gezellige mini-camping, chambres d'hôtes (Bed & Breakfast) en table d'hôtes in het prachtige Auvergne, Frankrijk.",
+    "welcomeText2": "Wij, Yvonne en Rob, heten u van harte welkom op ons stukje paradijs in het hartje van Frankrijk.",
+    "whatWeOffer": "Wat bieden wij?",
+    "whyTheName": "Waarom \"Les Deux Chevaux\"?",
+    "whyTheNameText1": "De naam \"Les Deux Chevaux\" verwijst naar de iconische Franse auto, de Citroën 2CV - oftewel \"deux chevaux\" (twee paardenkrachten).",
+    "whyTheNameText2": "Deze auto symboliseert het relaxte, authentieke Franse plattelandsleven dat wij onze gasten willen bieden.",
+    "impressions": "Impressies",
+    "readyForStay": "Klaar voor uw verblijf in de Auvergne?",
+    "ctaText": "Neem contact met ons op voor meer informatie of om een reservering te maken.",
+    "highlights": {
+      "camping": {
+        "title": "Mini-Camping",
+        "description": "6 ruime plekken voor tent of caravan in een ontspannen sfeer"
+      },
+      "chambres": {
+        "title": "Chambres d'Hôtes",
+        "description": "Comfortabele kamers met heerlijk Frans ontbijt"
+      },
+      "table": {
+        "title": "Table d'Hôtes",
+        "description": "Geniet van authentieke Franse maaltijden"
+      }
+    }
+  },
+  "whoAreWe": {
+    "heroSubtitle": "Maak kennis met Yvonne en Rob",
+    "title": "Yvonne van de Velde & Rob Nijholt",
+    "text1": "Wij zijn eind juni 2013 vanuit Zierikzee, Nederland, naar de Auvergne in Frankrijk verhuisd om ons droomleven te beginnen.",
+    "text2": "Nu runnen wij met veel plezier onze mini-camping en chambres d'hôtes. We heten u van harte welkom om de rust en schoonheid van de Auvergne met ons te delen.",
+    "text3": "Of u nu komt kamperen, overnachten in een van onze kamers, of genieten van onze table d'hôtes - wij zorgen ervoor dat u zich thuis voelt.",
+    "jipTitle": "Onze trouwe vriend Jip",
+    "jipText": "En dan is er nog Jip, ons trouwe maatje die u graag begroet bij aankomst! Jip is altijd blij om nieuwe gasten te ontmoeten en zorgt voor een warm welkom."
+  },
+  "whereAreWe": {
+    "heroSubtitle": "Onze locatie in het hart van de Auvergne",
+    "title": "Nades, Auvergne",
+    "text": "Wij bevinden ons in het pittoreske dorpje Nades (spreek uit: \"nade\"), gelegen in het uiterste zuiden van het departement Allier, één van de vier departementen in de regio Auvergne.",
+    "addressTitle": "Adres",
+    "addressNote": "Dit adres wordt herkend door zowel Google Maps als TomTom navigatiesystemen.",
+    "distances": "Afstanden",
+    "distance1": "Ongeveer 60 km ten noorden van Clermont-Ferrand",
+    "distance2": "Ongeveer 750 km van Zierikzee, Nederland (halverwege de zuidelijke route)",
+    "directions": "Routebeschrijving"
+  },
+  "theRegion": {
+    "heroTitle": "Wat heeft de streek te bieden?",
+    "heroSubtitle": "Ontdek de prachtige Auvergne",
+    "intro1": "De Auvergne biedt het hele jaar door schoonheid met activiteiten voor iedereen. Het is een plek waar je echt tot rust kunt komen.",
+    "intro2": "Laat de technologie achter en geniet van een complete reset in de natuur.",
+    "outdoorActivities": "Buitenactiviteiten",
+    "attractionsTitle": "Attracties binnen 60 km",
+    "winterTitle": "Ook in de winter",
+    "winterText1": "De Auvergne is ook in de winter prachtig, met mogelijkheden voor winterse wandelingen en het genieten van de rust.",
+    "winterText2": "Geniet van de besneeuwde landschappen en de gezellige sfeer bij de open haard.",
+    "impressions": "Impressies van de streek",
+    "activities": {
+      "hiking": {
+        "title": "Wandelen",
+        "description": "Talloze paden met verschillende moeilijkheidsgraden door het prachtige landschap."
+      },
+      "mountainBiking": {
+        "title": "Mountainbiken",
+        "description": "Een paradijs voor MTB-liefhebbers met uitdagende routes."
+      },
+      "cycling": {
+        "title": "Fietsen",
+        "description": "Ontdek de streek op de fiets via schilderachtige wegen."
+      },
+      "fishing": {
+        "title": "Vissen",
+        "description": "Vis in de rivier de Sioul, rijk aan diverse vissoorten."
+      },
+      "canoeing": {
+        "title": "Kanoën",
+        "description": "Vaar over de Sioul en geniet van de natuur vanaf het water."
+      },
+      "horseRiding": {
+        "title": "Paardrijden",
+        "description": "Verken de omgeving te paard of met een ezel."
+      }
+    },
+    "attractions": {
+      "puyDeDome": {
+        "title": "Puy de Dôme",
+        "description": "Iconische vulkaan met adembenemend uitzicht."
+      },
+      "puyDeSancy": {
+        "title": "Puy de Sancy",
+        "description": "Hoogste berg in het Centraal Massief."
+      },
+      "castles": {
+        "title": "Kastelen en ruïnes",
+        "description": "Rijk historisch erfgoed in de omgeving."
+      },
+      "vulcania": {
+        "title": "Parc Vulcania",
+        "description": "Avontuurlijk themapark over vulkanen bij Clermont-Ferrand."
+      },
+      "autoMuseum": {
+        "title": "Automuseum Bellenave",
+        "description": "Voor liefhebbers van klassieke auto's."
+      },
+      "fleaMarkets": {
+        "title": "Rommelmarkten",
+        "description": "Gezellige markten met unieke vondsten."
+      }
+    }
+  },
+  "whatToExpect": {
+    "heroTitle": "Wat kun je bij ons verwachten?",
+    "heroSubtitle": "Onze accommodaties en faciliteiten",
+    "intro": "Bij Les Deux Chevaux bieden we verschillende verblijfsmogelijkheden, van kamperen tot luxe kamers, allemaal met de warme gastvrijheid die u van ons mag verwachten.",
+    "chambresTitle": "Chambres d'Hôtes",
+    "rooms": {
+      "red": {
+        "name": "Rode Kamer",
+        "capacity": "2 personen",
+        "description": "Comfortabel en sfeervol ingericht"
+      },
+      "green": {
+        "name": "Groene Kamer",
+        "capacity": "2 personen",
+        "description": "Met uitzicht op de tuin"
+      },
+      "blue": {
+        "name": "Blauwe Kamer",
+        "capacity": "2-3 personen",
+        "description": "Ruim en licht"
+      },
+      "family": {
+        "name": "Familie/Vrienden Kamers",
+        "capacity": "Tot 7 personen",
+        "description": "Perfect voor groepen"
+      }
+    },
+    "campingTitle": "Mini-Camping",
+    "campingText": "Wij hebben 6 plekken voor tenten en caravans, met een ontspannen sfeer en alle nodige faciliteiten.",
+    "campingFeatures": {
+      "electricity": "Elektriciteit inbegrepen",
+      "dogs": "Honden welkom (aangelijnd)",
+      "quiet": "Rustige, groene omgeving",
+      "sanitary": "Gedeelde sanitaire voorzieningen"
+    },
+    "additionalTitle": "Aanvullende Verblijfsopties",
+    "caravan": {
+      "title": "Uitgeruste Caravan",
+      "text": "Voor wie wil kamperen zonder eigen spullen. Volledig ingericht en klaar voor gebruik.",
+      "note": "Minimaal 2 nachten verblijf"
+    },
+    "bergerie": {
+      "title": "La Bergerie",
+      "text": "Een romantisch huisje voor koppels. Privé en rustig gelegen op ons terrein.",
+      "note": "Perfect voor een romantisch uitje"
+    },
+    "tableTitle": "Table d'Hôtes",
+    "tableText": "Onze table d'hôtes biedt heerlijke, vers bereide maaltijden. Geniet samen met andere gasten van een authentieke Franse eetervaring.",
+    "tableFeatures": {
+      "dinner": "Driegangen diner met koffie",
+      "fresh": "Verse, lokale ingrediënten",
+      "atmosphere": "Gezellige sfeer met andere gasten"
+    },
+    "impressions": "Impressies"
+  },
+  "rates": {
+    "heroTitle": "Onze Tarieven",
+    "heroSubtitle": "Prijzen voor camping, kamers en maaltijden",
+    "campingTitle": "Camping",
+    "description": "Omschrijving",
+    "price": "Prijs",
+    "campingItems": {
+      "pitch": {
+        "description": "Plek (2 personen + auto)",
+        "price": "€17,50"
+      },
+      "extraPerson": {
+        "description": "Extra persoon",
+        "price": "€2,50"
+      },
+      "electricity": {
+        "description": "Elektriciteit",
+        "price": "Inbegrepen"
+      },
+      "dog": {
+        "description": "Hond (aangelijnd)",
+        "price": "Gratis"
+      },
+      "touristTax": {
+        "description": "Toeristenbelasting",
+        "price": "€0,25 p.p./dag"
+      }
+    },
+    "chambresTitle": "Chambres d'Hôtes (Bed & Breakfast)",
+    "accommodation": "Accommodatie",
+    "pricePerNight": "Prijs per nacht",
+    "details": "Details",
+    "chambresItems": {
+      "mainRoom": {
+        "name": "Kamer in hoofdgebouw",
+        "price": "€75,00",
+        "details": "2 personen, incl. ontbijt, eigen douche/toilet"
+      },
+      "longere": {
+        "name": "La Longère",
+        "price": "€80,00",
+        "details": "2 personen, incl. ontbijt, eigen badkamer"
+      },
+      "extraPerson": {
+        "name": "+ Extra persoon",
+        "price": "€30,00",
+        "details": "Per extra persoon"
+      },
+      "chezMarco": {
+        "name": "Chez Marco",
+        "price": "€80,00",
+        "details": "2 personen, incl. ontbijt, eigen badkamer"
+      },
+      "smallCaravan": {
+        "name": "Kleine caravan",
+        "price": "€70,00 / €65,00",
+        "details": "Met/zonder ontbijt (min. 2 nachten)"
+      },
+      "luxuryTent": {
+        "name": "Luxe tent",
+        "price": "€70,00 / €65,00",
+        "details": "Met/zonder ontbijt (min. 2 nachten)"
+      },
+      "bergerie": {
+        "name": "La Bergerie (huisje)",
+        "price": "€70,00 / €65,00",
+        "details": "Met/zonder ontbijt"
+      }
+    },
+    "tableTitle": "Table d'Hôtes (Maaltijden)",
+    "meal": "Maaltijd",
+    "tableItems": {
+      "dinner": {
+        "description": "Driegangen diner met koffie",
+        "price": "€20,00 p.p."
+      },
+      "drinks": {
+        "description": "Drankjes bij diner",
+        "price": "€2,00 per stuk"
+      },
+      "lunch": {
+        "description": "Lunch",
+        "price": "€7,50 p.p."
+      },
+      "breakfast": {
+        "description": "Ontbijt (los)",
+        "price": "€6,50 p.p."
+      }
+    }
+  },
+  "contact": {
+    "heroSubtitle": "Neem contact met ons op voor meer informatie of een reservering",
+    "contactDetails": "Contactgegevens",
+    "phoneYvonne": "Telefoon Yvonne",
+    "phoneRob": "Telefoon Rob",
+    "viewLocationText": "Bekijk onze locatie op Google Maps"
+  },
+  "footer": {
+    "contact": "Contact",
+    "address": "Adres",
+    "navigation": "Navigatie",
+    "allRightsReserved": "Alle rechten voorbehouden",
+    "rates": "Tarieven",
+    "theRegion": "De streek"
+  }
+}

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1,0 +1,188 @@
+export type Locale = "nl" | "fr";
+
+export interface Translations {
+  nav: {
+    home: string;
+    whoAreWe: string;
+    whereAreWe: string;
+    theRegion: string;
+    whatToExpect: string;
+    rates: string;
+    contact: string;
+  };
+  common: {
+    readMore: string;
+    contact: string;
+    viewRates: string;
+    openInGoogleMaps: string;
+    allRightsReserved: string;
+    address: string;
+    navigation: string;
+    phone: string;
+    email: string;
+    interested: string;
+    contactUs: string;
+    location: string;
+    viewOnGoogleMaps: string;
+    persons: string;
+    person: string;
+    perNight: string;
+    included: string;
+    free: string;
+  };
+  home: {
+    heroSubtitle: string;
+    welcomeTitle: string;
+    welcomeText1: string;
+    welcomeText2: string;
+    whatWeOffer: string;
+    whyTheName: string;
+    whyTheNameText1: string;
+    whyTheNameText2: string;
+    impressions: string;
+    readyForStay: string;
+    ctaText: string;
+    highlights: {
+      camping: { title: string; description: string };
+      chambres: { title: string; description: string };
+      table: { title: string; description: string };
+    };
+  };
+  whoAreWe: {
+    heroSubtitle: string;
+    title: string;
+    text1: string;
+    text2: string;
+    text3: string;
+    jipTitle: string;
+    jipText: string;
+  };
+  whereAreWe: {
+    heroSubtitle: string;
+    title: string;
+    text: string;
+    addressTitle: string;
+    addressNote: string;
+    distances: string;
+    distance1: string;
+    distance2: string;
+    directions: string;
+  };
+  theRegion: {
+    heroTitle: string;
+    heroSubtitle: string;
+    intro1: string;
+    intro2: string;
+    outdoorActivities: string;
+    attractionsTitle: string;
+    winterTitle: string;
+    winterText1: string;
+    winterText2: string;
+    impressions: string;
+    activities: {
+      hiking: { title: string; description: string };
+      mountainBiking: { title: string; description: string };
+      cycling: { title: string; description: string };
+      fishing: { title: string; description: string };
+      canoeing: { title: string; description: string };
+      horseRiding: { title: string; description: string };
+    };
+    attractions: {
+      puyDeDome: { title: string; description: string };
+      puyDeSancy: { title: string; description: string };
+      castles: { title: string; description: string };
+      vulcania: { title: string; description: string };
+      autoMuseum: { title: string; description: string };
+      fleaMarkets: { title: string; description: string };
+    };
+  };
+  whatToExpect: {
+    heroTitle: string;
+    heroSubtitle: string;
+    intro: string;
+    chambresTitle: string;
+    rooms: {
+      red: { name: string; capacity: string; description: string };
+      green: { name: string; capacity: string; description: string };
+      blue: { name: string; capacity: string; description: string };
+      family: { name: string; capacity: string; description: string };
+    };
+    campingTitle: string;
+    campingText: string;
+    campingFeatures: {
+      electricity: string;
+      dogs: string;
+      quiet: string;
+      sanitary: string;
+    };
+    additionalTitle: string;
+    caravan: {
+      title: string;
+      text: string;
+      note: string;
+    };
+    bergerie: {
+      title: string;
+      text: string;
+      note: string;
+    };
+    tableTitle: string;
+    tableText: string;
+    tableFeatures: {
+      dinner: string;
+      fresh: string;
+      atmosphere: string;
+    };
+    impressions: string;
+  };
+  rates: {
+    heroTitle: string;
+    heroSubtitle: string;
+    campingTitle: string;
+    description: string;
+    price: string;
+    campingItems: {
+      pitch: { description: string; price: string };
+      extraPerson: { description: string; price: string };
+      electricity: { description: string; price: string };
+      dog: { description: string; price: string };
+      touristTax: { description: string; price: string };
+    };
+    chambresTitle: string;
+    accommodation: string;
+    pricePerNight: string;
+    details: string;
+    chambresItems: {
+      mainRoom: { name: string; price: string; details: string };
+      longere: { name: string; price: string; details: string };
+      extraPerson: { name: string; price: string; details: string };
+      chezMarco: { name: string; price: string; details: string };
+      smallCaravan: { name: string; price: string; details: string };
+      luxuryTent: { name: string; price: string; details: string };
+      bergerie: { name: string; price: string; details: string };
+    };
+    tableTitle: string;
+    meal: string;
+    tableItems: {
+      dinner: { description: string; price: string };
+      drinks: { description: string; price: string };
+      lunch: { description: string; price: string };
+      breakfast: { description: string; price: string };
+    };
+  };
+  contact: {
+    heroSubtitle: string;
+    contactDetails: string;
+    phoneYvonne: string;
+    phoneRob: string;
+    viewLocationText: string;
+  };
+  footer: {
+    contact: string;
+    address: string;
+    navigation: string;
+    allRightsReserved: string;
+    rates: string;
+    theRegion: string;
+  };
+}


### PR DESCRIPTION
## Summary
- Add i18n infrastructure with React Context and JSON translation files
- Create NL/FR language toggle button in the header
- Translate all content across 7 pages, header, and footer
- Language preference persisted in localStorage
- Dutch is the default language

## Features
- **LanguageToggle component**: Simple NL/FR button that switches between languages
- **Translation files**: `nl.json` and `fr.json` with ~120 translation keys each
- **Type-safe**: Full TypeScript support with `Translations` interface
- **Persistent**: User's language preference saved in localStorage

## Test plan
- [x] Build succeeds (`npm run build`)
- [ ] Click NL/FR toggle and verify all text changes
- [ ] Refresh page and verify language preference persists
- [ ] Test on mobile view