### PR TITLE
Add embedded OpenStreetMap to contact and location pages

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslation } from "@/i18n";
+import Map from "@/components/Map";
 
 export default function Contact() {
   const { t } = useTranslation();
@@ -158,20 +159,16 @@ export default function Contact() {
               <h2 className="text-2xl font-bold text-amber-900 mb-8">
                 {t.common.location}
               </h2>
-              <div className="bg-gray-100 rounded-xl overflow-hidden h-80 flex items-center justify-center">
-                <div className="text-center p-8">
-                  <p className="text-gray-600 mb-4">
-                    {t.contact.viewLocationText}
-                  </p>
-                  <a
-                    href="https://www.google.com/maps/search/?api=1&query=7+Impasse+de+la+Tranquillité+Nades+France"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-block px-6 py-3 bg-amber-600 text-white font-semibold rounded-lg hover:bg-amber-700 transition-colors"
-                  >
-                    {t.common.openInGoogleMaps}
-                  </a>
-                </div>
+              <Map className="h-80" />
+              <div className="mt-4 text-center">
+                <a
+                  href="https://www.google.com/maps/search/?api=1&query=7+Impasse+de+la+Tranquillité+Nades+France"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-block px-6 py-3 bg-amber-600 text-white font-semibold rounded-lg hover:bg-amber-700 transition-colors"
+                >
+                  {t.common.openInGoogleMaps}
+                </a>
               </div>
             </div>
           </div>

--- a/src/app/waar-zijn-wij/page.tsx
+++ b/src/app/waar-zijn-wij/page.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Hero from "@/components/Hero";
 import { getImagePath } from "@/lib/config";
 import { useTranslation } from "@/i18n";
+import Map from "@/components/Map";
 
 export default function WaarZijnWij() {
   const { t } = useTranslation();
@@ -63,19 +64,22 @@ export default function WaarZijnWij() {
                 />
               </div>
 
-              {/* Map placeholder */}
-              <div className="bg-gray-100 rounded-xl p-8 text-center">
+              {/* Map */}
+              <div>
                 <h3 className="text-lg font-semibold text-gray-700 mb-4">
                   {t.whereAreWe.directions}
                 </h3>
-                <a
-                  href="https://www.google.com/maps/search/?api=1&query=7+Impasse+de+la+Tranquillité+Nades+France"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-block px-6 py-3 bg-amber-600 text-white font-semibold rounded-lg hover:bg-amber-700 transition-colors"
-                >
-                  {t.common.viewOnGoogleMaps}
-                </a>
+                <Map className="h-64" />
+                <div className="mt-4 text-center">
+                  <a
+                    href="https://www.google.com/maps/search/?api=1&query=7+Impasse+de+la+Tranquillité+Nades+France"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-block px-6 py-3 bg-amber-600 text-white font-semibold rounded-lg hover:bg-amber-700 transition-colors"
+                  >
+                    {t.common.viewOnGoogleMaps}
+                  </a>
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+interface MapProps {
+  className?: string;
+}
+
+// Coordinates for 7 Impasse de la Tranquillité, Nades, France
+const LAT = 46.2833;
+const LON = 3.0667;
+const ZOOM = 14;
+
+export default function Map({ className = "h-80" }: MapProps) {
+  // OpenStreetMap embed URL with marker
+  const mapUrl = `https://www.openstreetmap.org/export/embed.html?bbox=${LON - 0.02},${LAT - 0.01},${LON + 0.02},${LAT + 0.01}&layer=mapnik&marker=${LAT},${LON}`;
+
+  return (
+    <div className={`rounded-xl overflow-hidden shadow-lg ${className}`}>
+      <iframe
+        src={mapUrl}
+        width="100%"
+        height="100%"
+        style={{ border: 0 }}
+        loading="lazy"
+        referrerPolicy="no-referrer-when-downgrade"
+        title="Location of Les Deux Chevaux"
+        className="w-full h-full"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add embedded OpenStreetMap showing Les Deux Chevaux location
- Maps appear on Contact page and Waar zijn wij (Where are we) page
- Keep Google Maps button for navigation/directions

## Changes
- Created reusable `Map` component using OpenStreetMap embed (no API key needed)
- Updated Contact page to show actual map instead of placeholder
- Updated Waar zijn wij page to show actual map instead of placeholder