### PR TITLE
Fix lightbox close button not working

### DIFF
--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -57,8 +57,11 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
           onClick={() => setSelectedImage(null)}
         >
           <button
-            className="absolute top-6 right-6 text-white/80 hover:text-white transition-colors p-2 rounded-full hover:bg-white/10"
-            onClick={() => setSelectedImage(null)}
+            className="absolute top-6 right-6 z-10 text-white/80 hover:text-white transition-colors p-2 rounded-full hover:bg-white/10"
+            onClick={(e) => {
+              e.stopPropagation();
+              setSelectedImage(null);
+            }}
           >
             <svg
               className="h-8 w-8"


### PR DESCRIPTION
## Summary
- Add `z-10` to ensure close button is above image container
- Add `e.stopPropagation()` to properly handle click events

## Problem
The close button (X) in the image gallery lightbox wasn't responding to clicks because the image container was overlapping it.