### PR TITLE
Fix image paths by adding basePath prop

### DIFF
--- a/src/app/de-streek/page.tsx
+++ b/src/app/de-streek/page.tsx
@@ -176,6 +176,7 @@ export default function DeStreek() {
                 fill
                 className="object-cover"
                 sizes="(max-width: 1024px) 100vw, 50vw"
+                basePath="/lesdeuxchevaux"
               />
             </div>
             <div>

--- a/src/app/waar-zijn-wij/page.tsx
+++ b/src/app/waar-zijn-wij/page.tsx
@@ -58,6 +58,7 @@ export default function WaarZijnWij() {
                   fill
                   className="object-cover"
                   sizes="(max-width: 1024px) 100vw, 50vw"
+                  basePath="/lesdeuxchevaux"
                 />
               </div>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -34,6 +34,7 @@ export default function Header() {
                 height={85}
                 className="h-16 w-auto"
                 priority
+                basePath="/lesdeuxchevaux"
               />
             </Link>
           </div>

--- a/src/components/OptimizedImage.tsx
+++ b/src/components/OptimizedImage.tsx
@@ -40,6 +40,7 @@ export function OptimizedImage({
         priority={priority}
         sizes={sizes}
         placeholder="blur"
+        basePath="/lesdeuxchevaux"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds `basePath="/lesdeuxchevaux"` prop to all ExportedImage components
- Required for GitHub Pages deployment to subfolder

## Root cause
The `next-image-export-optimizer` package doesn't automatically use the Next.js `basePath` config. It requires the basePath to be passed explicitly as a prop.

## Test plan
- [ ] Verify images load on deployed site