### PR TITLE
Fix image optimization to include all public images

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,7 +12,7 @@ const nextConfig: NextConfig = {
   transpilePackages: ["next-image-export-optimizer"],
   trailingSlash: true,
   env: {
-    nextImageExportOptimizer_imageFolderPath: "public/uploads",
+    nextImageExportOptimizer_imageFolderPath: "public",
     nextImageExportOptimizer_exportFolderPath: "out",
     nextImageExportOptimizer_quality: "80",
     nextImageExportOptimizer_storePicturesInWEBP: "true",


### PR DESCRIPTION
Changed imageFolderPath from 'public/uploads' to 'public' to include logo.jpg and other root images.