### PR TITLE
Fix OptimizedImage: remove wrapper div for fill images

### DIFF
--- a/src/components/OptimizedImage.tsx
+++ b/src/components/OptimizedImage.tsx
@@ -30,13 +30,30 @@ export function OptimizedImage({
     ? { fill: true }
     : { width: width || 1920, height: height || 1080 };
 
-  return (
-    <div className={fill ? `relative ${className}` : className} onClick={onClick}>
+  // When using fill, don't wrap in an extra div - let the parent handle positioning
+  if (fill) {
+    return (
       <ExportedImage
         src={src}
         alt={alt}
-        {...imageProps}
-        className={fill ? "object-cover" : ""}
+        fill
+        className={`object-cover ${className}`}
+        priority={priority}
+        sizes={sizes}
+        placeholder="blur"
+        basePath="/lesdeuxchevaux"
+        onClick={onClick}
+      />
+    );
+  }
+
+  return (
+    <div className={className} onClick={onClick}>
+      <ExportedImage
+        src={src}
+        alt={alt}
+        width={width || 1920}
+        height={height || 1080}
         priority={priority}
         sizes={sizes}
         placeholder="blur"


### PR DESCRIPTION
When using fill mode, the extra wrapper div was causing the image to have no dimensions. Now the ExportedImage is returned directly without a wrapper, allowing CSS fill to work properly.