### PR TITLE
Fix rates table text overlap

### DIFF
--- a/src/app/tarieven/page.tsx
+++ b/src/app/tarieven/page.tsx
@@ -87,19 +87,14 @@ export default function Tarieven() {
           <h2 className="text-3xl font-bold text-amber-900 mb-8">
             {t.rates.chambresTitle}
           </h2>
-          <div className="overflow-x-auto max-w-3xl">
-            <table className="w-full bg-white rounded-xl shadow-sm table-fixed">
-              <colgroup>
-                <col className="w-[35%]" />
-                <col className="w-[15%]" />
-                <col className="w-[50%]" />
-              </colgroup>
+          <div className="overflow-x-auto">
+            <table className="w-full bg-white rounded-xl shadow-sm">
               <thead>
                 <tr className="bg-amber-100">
                   <th className="px-4 py-3 text-left text-amber-900 font-semibold">
                     {t.rates.accommodation}
                   </th>
-                  <th className="px-4 py-3 text-right text-amber-900 font-semibold whitespace-nowrap">
+                  <th className="px-4 py-3 text-right text-amber-900 font-semibold">
                     {t.rates.pricePerNight}
                   </th>
                   <th className="px-4 py-3 text-left text-amber-900 font-semibold">

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -244,7 +244,7 @@
     },
     "chambresTitle": "Chambres d'Hôtes (Bed & Breakfast)",
     "accommodation": "Hébergement",
-    "pricePerNight": "Prix/nuit",
+    "pricePerNight": "Prix par nuit",
     "details": "Détails",
     "chambresItems": {
       "mainRoom": {

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -244,7 +244,7 @@
     },
     "chambresTitle": "Chambres d'Hôtes (Bed & Breakfast)",
     "accommodation": "Accommodatie",
-    "pricePerNight": "Prijs/nacht",
+    "pricePerNight": "Prijs per nacht",
     "details": "Details",
     "chambresItems": {
       "mainRoom": {


### PR DESCRIPTION
## Samenvatting
- Verwijder table-fixed layout om natuurlijke kolombreedtes toe te staan
- Verwijder colgroup met vaste kolombreedtes
- Herstel prijsheader naar "Prijs per nacht" / "Prix par nuit" zodat tekst natuurlijk kan afbreken op smalle schermen

Fixes het probleem waarbij tekst over elkaar heen viel in de Chambres d'Hôtes tabel.