### PR TITLE
Grote update accommodaties en prijzen (email vader)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,13 +33,13 @@ export default function Home() {
     {
       title: t.home.highlights.chambres.title,
       description: t.home.highlights.chambres.description,
-      image: "/uploads/2016/09/Les-2CV-3-copy.jpg",
+      image: "/uploads/2016/09/Rode-kamer.jpg",
       href: "/wat-te-verwachten",
     },
     {
       title: t.home.highlights.table.title,
       description: t.home.highlights.table.description,
-      image: "/uploads/2016/09/tafelen.jpg",
+      image: "/uploads/2020/07/proost.jpg",
       href: "/tarieven",
     },
   ];

--- a/src/app/tarieven/page.tsx
+++ b/src/app/tarieven/page.tsx
@@ -45,14 +45,6 @@ export default function Tarieven() {
                 </tr>
                 <tr className="hover:bg-amber-50">
                   <td className="px-6 py-4">
-                    {t.rates.campingItems.extraPerson.description}
-                  </td>
-                  <td className="px-6 py-4 text-right font-medium">
-                    {t.rates.campingItems.extraPerson.price}
-                  </td>
-                </tr>
-                <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4">
                     {t.rates.campingItems.electricity.description}
                   </td>
                   <td className="px-6 py-4 text-right font-medium text-green-600">
@@ -65,14 +57,6 @@ export default function Tarieven() {
                   </td>
                   <td className="px-6 py-4 text-right font-medium text-green-600">
                     {t.rates.campingItems.dog.price}
-                  </td>
-                </tr>
-                <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4">
-                    {t.rates.campingItems.touristTax.description}
-                  </td>
-                  <td className="px-6 py-4 text-right font-medium">
-                    {t.rates.campingItems.touristTax.price}
                   </td>
                 </tr>
               </tbody>
@@ -126,17 +110,6 @@ export default function Tarieven() {
                   </td>
                 </tr>
                 <tr className="hover:bg-amber-50">
-                  <td className="px-4 py-3 text-gray-500 pl-8">
-                    {t.rates.chambresItems.extraPerson.name}
-                  </td>
-                  <td className="px-4 py-3 text-right font-medium">
-                    {t.rates.chambresItems.extraPerson.price}
-                  </td>
-                  <td className="px-4 py-3 text-gray-600">
-                    {t.rates.chambresItems.extraPerson.details}
-                  </td>
-                </tr>
-                <tr className="hover:bg-amber-50">
                   <td className="px-4 py-3 font-medium">
                     {t.rates.chambresItems.chezMarco.name}
                   </td>
@@ -145,17 +118,6 @@ export default function Tarieven() {
                   </td>
                   <td className="px-4 py-3 text-gray-600">
                     {t.rates.chambresItems.chezMarco.details}
-                  </td>
-                </tr>
-                <tr className="hover:bg-amber-50">
-                  <td className="px-4 py-3 text-gray-500 pl-8">
-                    {t.rates.chambresItems.extraPerson.name}
-                  </td>
-                  <td className="px-4 py-3 text-right font-medium">
-                    {t.rates.chambresItems.extraPerson.price}
-                  </td>
-                  <td className="px-4 py-3 text-gray-600">
-                    {t.rates.chambresItems.extraPerson.details}
                   </td>
                 </tr>
                 <tr className="hover:bg-amber-50">

--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -7,12 +7,12 @@ import { useTranslation } from "@/i18n";
 
 const accommodationImages = [
   {
-    src: "/uploads/2016/09/Les-2CV-3-copy.jpg",
+    src: "/uploads/2016/09/Rode-kamer.jpg",
     alt: "Rode Kamer",
   },
   { src: "/uploads/2020/07/camping-2.jpg", alt: "Camping" },
   { src: "/uploads/2020/07/Bergerie.jpg", alt: "La Bergerie" },
-  { src: "/uploads/2016/09/tafelen.jpg", alt: "Buiten tafelen" },
+  { src: "/uploads/2020/07/proost.jpg", alt: "Table d'Hôtes" },
 ];
 
 export default function WatTeVerwachten() {
@@ -29,6 +29,11 @@ export default function WatTeVerwachten() {
       capacity: t.whatToExpect.rooms.chezMarco.capacity,
       description: t.whatToExpect.rooms.chezMarco.description,
     },
+    {
+      name: t.whatToExpect.rooms.longere.name,
+      capacity: t.whatToExpect.rooms.longere.capacity,
+      description: t.whatToExpect.rooms.longere.description,
+    },
   ];
 
   return (
@@ -36,7 +41,7 @@ export default function WatTeVerwachten() {
       <Hero
         title={t.whatToExpect.heroTitle}
         subtitle={t.whatToExpect.heroSubtitle}
-        image="/uploads/2016/09/Les-2CV-3-copy.jpg"
+        image="/uploads/2016/09/Rode-kamer.jpg"
       />
 
       {/* Introduction */}
@@ -67,7 +72,7 @@ export default function WatTeVerwachten() {
           </div>
           <div className="relative h-80 rounded-xl overflow-hidden shadow-lg max-w-3xl mx-auto">
             <OptimizedImage
-              src="/uploads/2016/09/Les-2CV-3-copy.jpg"
+              src="/uploads/2016/09/Rode-kamer.jpg"
               alt="Chambre"
               fill
               sizes="(max-width: 1024px) 100vw, 768px"
@@ -175,7 +180,7 @@ export default function WatTeVerwachten() {
             </div>
             <div className="relative h-80 rounded-xl overflow-hidden shadow-lg">
               <OptimizedImage
-                src="/uploads/2016/09/tafelen.jpg"
+                src="/uploads/2020/07/proost.jpg"
                 alt="Table d'Hôtes"
                 fill
                 sizes="(max-width: 1024px) 100vw, 50vw"

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -172,8 +172,13 @@
       },
       "chezMarco": {
         "name": "Chez Marco",
-        "capacity": "Jusqu'à 6 personnes",
-        "description": "Hébergement spacieux avec salle de bain privée, parfait pour les familles ou groupes"
+        "capacity": "Jusqu'à 4 personnes",
+        "description": "Maison accueillante avec 1 salle de bain et 2 toilettes. Plus de personnes possible sur demande."
+      },
+      "longere": {
+        "name": "La Longère",
+        "capacity": "2-7 personnes",
+        "description": "Spacieux gîte avec grand salon lumineux et cuisine équipée. 2 salles de bain, 2 toilettes. Lits faits à l'arrivée, serviettes fournies. Terrasse privée."
       }
     },
     "campingTitle": "Mini-Camping",
@@ -186,20 +191,20 @@
     },
     "additionalTitle": "Options d'hébergement supplémentaires",
     "caravan": {
-      "title": "Caravane équipée",
-      "text": "Pour ceux qui veulent camper sans leur propre équipement. Entièrement équipée et prête à l'emploi.",
+      "title": "Petite Caravane",
+      "text": "Caravane confortable pour 1-2 personnes. Idéale pour camper sans son propre équipement.",
       "note": "Minimum 2 nuits"
     },
     "bergerie": {
       "title": "La Bergerie",
-      "text": "Un petit cottage romantique pour les couples. Privé et paisiblement situé sur notre terrain.",
-      "note": "Parfait pour une escapade romantique"
+      "text": "Une petite maison de gnome accueillante avec un bon lit et 2 chaises. Uniquement pour dormir - sanitaires dans le bâtiment adjacent.",
+      "note": "Cosy et romantique"
     },
     "tableTitle": "Table d'Hôtes",
     "tableText": "Notre table d'hôtes propose de délicieux repas fraîchement préparés. Profitez d'une expérience culinaire française authentique avec d'autres hôtes.",
     "tableFeatures": {
       "dinner": "Dîner trois services avec café",
-      "fresh": "Ingrédients frais et locaux",
+      "fresh": "Repas fraîchement préparés",
       "atmosphere": "Ambiance conviviale avec d'autres hôtes"
     },
     "impressions": "Impressions"
@@ -212,12 +217,8 @@
     "price": "Prix",
     "campingItems": {
       "pitch": {
-        "description": "Emplacement (2 personnes + voiture)",
-        "price": "17,50 €"
-      },
-      "extraPerson": {
-        "description": "Personne supplémentaire",
-        "price": "2,50 €"
+        "description": "Emplacement par nuit",
+        "price": "20,00 €"
       },
       "electricity": {
         "description": "Électricité",
@@ -226,10 +227,6 @@
       "dog": {
         "description": "Chien (en laisse)",
         "price": "Gratuit"
-      },
-      "touristTax": {
-        "description": "Taxe de séjour",
-        "price": "0,25 € p.p./jour"
       }
     },
     "chambresTitle": "Chambres d'Hôtes (Bed & Breakfast)",
@@ -238,39 +235,34 @@
     "details": "Détails",
     "chambresItems": {
       "mainRoom": {
-        "name": "Chambre dans bâtiment principal",
+        "name": "Chambre Rouge",
         "price": "75,00 €",
-        "details": "2 personnes, petit-déj. incl., douche/WC privés"
+        "details": "2 personnes, salle de bain privée"
       },
       "longere": {
-        "name": "La Longère",
-        "price": "80,00 €",
-        "details": "2 personnes, petit-déj. incl., salle de bain privée"
-      },
-      "extraPerson": {
-        "name": "+ Personne supplémentaire",
-        "price": "30,00 €",
-        "details": "Par personne supplémentaire"
+        "name": "La Longère (gîte)",
+        "price": "80,00 € / 560 € p.s.",
+        "details": "2-7 pers, 80€/nuit ou 560€/sem (haute saison), 500€/sem (basse saison)"
       },
       "chezMarco": {
         "name": "Chez Marco",
-        "price": "80,00 €",
-        "details": "Jusqu'à 6 personnes, petit-déj. incl., salle de bain privée"
+        "price": "80,00 € / 140,00 €",
+        "details": "80€ (1 chambre) ou 140€ (2 chambres), jusqu'à 4 personnes"
       },
       "smallCaravan": {
         "name": "Petite caravane",
-        "price": "70,00 € / 65,00 €",
-        "details": "Avec/sans petit-déjeuner (min. 2 nuits)"
+        "price": "60,00 €",
+        "details": "1-2 personnes, min. 2 nuits"
       },
       "luxuryTent": {
-        "name": "Tente de luxe",
-        "price": "70,00 € / 65,00 €",
-        "details": "Avec/sans petit-déjeuner (min. 2 nuits)"
+        "name": "Tente équipée",
+        "price": "60,00 €",
+        "details": "Min. 2 nuits"
       },
       "bergerie": {
-        "name": "La Bergerie (cottage)",
-        "price": "70,00 € / 65,00 €",
-        "details": "Avec/sans petit-déjeuner"
+        "name": "La Bergerie",
+        "price": "60,00 €",
+        "details": "Petite maison cosy, uniquement pour dormir"
       }
     },
     "tableTitle": "Table d'Hôtes (Repas)",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -172,8 +172,13 @@
       },
       "chezMarco": {
         "name": "Chez Marco",
-        "capacity": "Tot 6 personen",
-        "description": "Ruime accommodatie met eigen badkamer, perfect voor families of groepen"
+        "capacity": "Tot 4 personen",
+        "description": "Gezellig huis met 1 badkamer en 2 toiletten. Meer personen in overleg mogelijk."
+      },
+      "longere": {
+        "name": "La Longère",
+        "capacity": "2-7 personen",
+        "description": "Ruim vakantiehuis met grote, lichte woonkamer en ingerichte keuken. 2 badkamers, 2 toiletten. Bedden opgemaakt bij aankomst, handdoeken aanwezig. Eigen terras."
       }
     },
     "campingTitle": "Mini-Camping",
@@ -186,20 +191,20 @@
     },
     "additionalTitle": "Aanvullende Verblijfsopties",
     "caravan": {
-      "title": "Uitgeruste Caravan",
-      "text": "Voor wie wil kamperen zonder eigen spullen. Volledig ingericht en klaar voor gebruik.",
+      "title": "Kleine Caravan",
+      "text": "Gezellige caravan voor 1-2 personen. Ideaal voor wie wil kamperen zonder eigen spullen.",
       "note": "Minimaal 2 nachten verblijf"
     },
     "bergerie": {
       "title": "La Bergerie",
-      "text": "Een romantisch huisje voor koppels. Privé en rustig gelegen op ons terrein.",
-      "note": "Perfect voor een romantisch uitje"
+      "text": "Een gezellig kabouterhuisje met een goed bed en 2 stoelen. Echt alleen om in te slapen - sanitair bevindt zich in het gebouwtje ernaast.",
+      "note": "Knus en romantisch"
     },
     "tableTitle": "Table d'Hôtes",
     "tableText": "Onze table d'hôtes biedt heerlijke, vers bereide maaltijden. Geniet samen met andere gasten van een authentieke Franse eetervaring.",
     "tableFeatures": {
       "dinner": "Driegangen diner met koffie",
-      "fresh": "Verse, lokale ingrediënten",
+      "fresh": "Vers bereide maaltijden",
       "atmosphere": "Gezellige sfeer met andere gasten"
     },
     "impressions": "Impressies"
@@ -212,12 +217,8 @@
     "price": "Prijs",
     "campingItems": {
       "pitch": {
-        "description": "Plek (2 personen + auto)",
-        "price": "€17,50"
-      },
-      "extraPerson": {
-        "description": "Extra persoon",
-        "price": "€2,50"
+        "description": "Campingplek per nacht",
+        "price": "€20,00"
       },
       "electricity": {
         "description": "Elektriciteit",
@@ -226,10 +227,6 @@
       "dog": {
         "description": "Hond (aangelijnd)",
         "price": "Gratis"
-      },
-      "touristTax": {
-        "description": "Toeristenbelasting",
-        "price": "€0,25 p.p./dag"
       }
     },
     "chambresTitle": "Chambres d'Hôtes (Bed & Breakfast)",
@@ -238,39 +235,34 @@
     "details": "Details",
     "chambresItems": {
       "mainRoom": {
-        "name": "Kamer in hoofdgebouw",
+        "name": "Rode Kamer",
         "price": "€75,00",
-        "details": "2 personen, incl. ontbijt, eigen douche/toilet"
+        "details": "2 personen, eigen badkamer"
       },
       "longere": {
-        "name": "La Longère",
-        "price": "€80,00",
-        "details": "2 personen, incl. ontbijt, eigen badkamer"
-      },
-      "extraPerson": {
-        "name": "+ Extra persoon",
-        "price": "€30,00",
-        "details": "Per extra persoon"
+        "name": "La Longère (gîte)",
+        "price": "€80,00 / €560,- p.w.",
+        "details": "2-7 pers, €80/nacht of €560/week (hoogseizoen), €500/week (laagseizoen)"
       },
       "chezMarco": {
         "name": "Chez Marco",
-        "price": "€80,00",
-        "details": "Tot 6 personen, incl. ontbijt, eigen badkamer"
+        "price": "€80,00 / €140,00",
+        "details": "€80 (1 kamer) of €140 (2 kamers), tot 4 personen"
       },
       "smallCaravan": {
         "name": "Kleine caravan",
-        "price": "€70,00 / €65,00",
-        "details": "Met/zonder ontbijt (min. 2 nachten)"
+        "price": "€60,00",
+        "details": "1-2 personen, min. 2 nachten"
       },
       "luxuryTent": {
-        "name": "Luxe tent",
-        "price": "€70,00 / €65,00",
-        "details": "Met/zonder ontbijt (min. 2 nachten)"
+        "name": "Ingerichte tent",
+        "price": "€60,00",
+        "details": "Min. 2 nachten"
       },
       "bergerie": {
-        "name": "La Bergerie (huisje)",
-        "price": "€70,00 / €65,00",
-        "details": "Met/zonder ontbijt"
+        "name": "La Bergerie",
+        "price": "€60,00",
+        "details": "Knus huisje, alleen om te slapen"
       }
     },
     "tableTitle": "Table d'Hôtes (Maaltijden)",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -109,6 +109,7 @@ export interface Translations {
     rooms: {
       red: { name: string; capacity: string; description: string };
       chezMarco: { name: string; capacity: string; description: string };
+      longere: { name: string; capacity: string; description: string };
     };
     campingTitle: string;
     campingText: string;
@@ -146,10 +147,8 @@ export interface Translations {
     price: string;
     campingItems: {
       pitch: { description: string; price: string };
-      extraPerson: { description: string; price: string };
       electricity: { description: string; price: string };
       dog: { description: string; price: string };
-      touristTax: { description: string; price: string };
     };
     chambresTitle: string;
     accommodation: string;
@@ -158,7 +157,6 @@ export interface Translations {
     chambresItems: {
       mainRoom: { name: string; price: string; details: string };
       longere: { name: string; price: string; details: string };
-      extraPerson: { name: string; price: string; details: string };
       chezMarco: { name: string; price: string; details: string };
       smallCaravan: { name: string; price: string; details: string };
       luxuryTent: { name: string; price: string; details: string };


### PR DESCRIPTION
## Wijzigingen op basis van email vader

### Foto's verwijderd/vervangen
- ❌ `tafelen.jpg` - overleden persoon op foto
- ❌ Groene kamer foto → vervangen door Rode kamer foto

### Accommodaties bijgewerkt

| Accommodatie | Prijs | Details |
|--------------|-------|---------|
| Rode Kamer | €75/nacht | 2 pers, eigen badkamer |
| La Longère (gîte) | €80/nacht, €560/week | 2-7 pers, hoogste inkomstenbron |
| Chez Marco | €80 of €140 | 1 of 2 kamers, tot 4 pers |
| Kleine caravan | €60/nacht | 1-2 pers, min. 2 nachten |
| Ingerichte tent | €60/nacht | min. 2 nachten |
| La Bergerie | €60/nacht | Kabouterhuisje, alleen slapen |
| Camping | €20/nacht | Was €17,50 |

### Table d'hôtes
- Verwijderd: tekst over "lokale producten" (alles komt uit de LIDL 🤣)

### Opgeschoond
- extraPerson en touristTax verwijderd uit camping
- extraPerson verwijderd uit kamers