### PR TITLE
Update region activities and attractions

### DIFF
--- a/src/app/de-streek/page.tsx
+++ b/src/app/de-streek/page.tsx
@@ -45,11 +45,6 @@ export default function DeStreek() {
       icon: "🛶",
     },
     {
-      title: t.theRegion.activities.horseRiding.title,
-      description: t.theRegion.activities.horseRiding.description,
-      icon: "🐴",
-    },
-    {
       title: t.theRegion.activities.motorcycling.title,
       description: t.theRegion.activities.motorcycling.description,
       icon: "🏍️",
@@ -99,6 +94,26 @@ export default function DeStreek() {
     {
       title: t.theRegion.attractions.shoppingTowns.title,
       description: t.theRegion.attractions.shoppingTowns.description,
+    },
+    {
+      title: t.theRegion.attractions.paleopolis.title,
+      description: t.theRegion.attractions.paleopolis.description,
+    },
+    {
+      title: t.theRegion.attractions.accrobranche.title,
+      description: t.theRegion.attractions.accrobranche.description,
+    },
+    {
+      title: t.theRegion.attractions.charroux.title,
+      description: t.theRegion.attractions.charroux.description,
+    },
+    {
+      title: t.theRegion.attractions.vichy.title,
+      description: t.theRegion.attractions.vichy.description,
+    },
+    {
+      title: t.theRegion.attractions.troncais.title,
+      description: t.theRegion.attractions.troncais.description,
     },
   ];
 

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -101,15 +101,11 @@
       },
       "fishing": {
         "title": "Pêche",
-        "description": "Pêchez dans la rivière Sioule, riche en espèces de poissons diverses."
+        "description": "Pêchez dans la rivière Sioule ou dans l'un des 2 étangs de pêche, riches en espèces diverses."
       },
       "canoeing": {
         "title": "Canoë",
         "description": "Naviguez sur la Sioule et profitez de la nature depuis l'eau."
-      },
-      "horseRiding": {
-        "title": "Équitation",
-        "description": "Explorez les environs à cheval ou à dos d'âne."
       },
       "motorcycling": {
         "title": "Moto",
@@ -125,7 +121,7 @@
       },
       "swimming": {
         "title": "Baignade",
-        "description": "Lacs de baignade et rivières avec rapides à proximité."
+        "description": "Baignade au Plan d'eau de Servant, Saint-Éloy-les-Mines, Vieure ou Saint-Clément."
       }
     },
     "attractions": {
@@ -156,6 +152,26 @@
       "shoppingTowns": {
         "title": "Villes commerçantes",
         "description": "Centres commerciaux et villes agréables dans les environs."
+      },
+      "paleopolis": {
+        "title": "Paléopolis (Gannat)",
+        "description": "Parc de dinosaures avec fossiles, squelettes et dinosaures grandeur nature."
+      },
+      "accrobranche": {
+        "title": "Accrobranche",
+        "description": "Plusieurs parcs accrobranche dans la région pour tous les âges et niveaux."
+      },
+      "charroux": {
+        "title": "Charroux",
+        "description": "Un des 'Plus Beaux Villages de France', à 10 km."
+      },
+      "vichy": {
+        "title": "Vichy",
+        "description": "Thermes historiques et magnifique architecture Belle Époque."
+      },
+      "troncais": {
+        "title": "Forêt de Tronçais",
+        "description": "Plus grande chênaie d'Europe avec étangs de baignade et sentiers de randonnée."
       }
     }
   },

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -101,15 +101,11 @@
       },
       "fishing": {
         "title": "Vissen",
-        "description": "Vis in de rivier de Sioul, rijk aan diverse vissoorten."
+        "description": "Vis in de rivier de Sioule of in één van de 2 vismeren, rijk aan diverse vissoorten."
       },
       "canoeing": {
         "title": "Kanoën",
-        "description": "Vaar over de Sioul en geniet van de natuur vanaf het water."
-      },
-      "horseRiding": {
-        "title": "Paardrijden",
-        "description": "Verken de omgeving te paard of met een ezel."
+        "description": "Vaar over de Sioule en geniet van de natuur vanaf het water."
       },
       "motorcycling": {
         "title": "Motortoeren",
@@ -125,7 +121,7 @@
       },
       "swimming": {
         "title": "Zwemmen",
-        "description": "Zwemmeren en rivieren met stroomversnellingen in de buurt."
+        "description": "Zwemmen in Plan d'eau de Servant, Saint-Éloy-les-Mines, Vieure of Saint-Clément."
       }
     },
     "attractions": {
@@ -156,6 +152,26 @@
       "shoppingTowns": {
         "title": "Winkelsteden",
         "description": "Winkelcentra en gezellige stadjes in de omgeving."
+      },
+      "paleopolis": {
+        "title": "Paléopolis (Gannat)",
+        "description": "Dinopark met fossielen, skeletten en levensgrote dinosaurussen."
+      },
+      "accrobranche": {
+        "title": "Klimparken",
+        "description": "Meerdere accrobranche parken in de omgeving voor alle leeftijden en niveaus."
+      },
+      "charroux": {
+        "title": "Charroux",
+        "description": "Een van de 'Mooiste Dorpen van Frankrijk', op 10 km afstand."
+      },
+      "vichy": {
+        "title": "Vichy",
+        "description": "Historische thermale baden en prachtige Belle Époque architectuur."
+      },
+      "troncais": {
+        "title": "Forêt de Tronçais",
+        "description": "Grootste eikenbos van Europa met zwemvijvers en wandelpaden."
       }
     }
   },

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -85,7 +85,6 @@ export interface Translations {
       cycling: { title: string; description: string };
       fishing: { title: string; description: string };
       canoeing: { title: string; description: string };
-      horseRiding: { title: string; description: string };
       motorcycling: { title: string; description: string };
       golf: { title: string; description: string };
       climbing: { title: string; description: string };
@@ -99,6 +98,11 @@ export interface Translations {
       autoMuseum: { title: string; description: string };
       fleaMarkets: { title: string; description: string };
       shoppingTowns: { title: string; description: string };
+      paleopolis: { title: string; description: string };
+      accrobranche: { title: string; description: string };
+      charroux: { title: string; description: string };
+      vichy: { title: string; description: string };
+      troncais: { title: string; description: string };
     };
   };
   whatToExpect: {


### PR DESCRIPTION
## Summary
- Update activities and attractions on "De Streek" page

## Activities
- Vissen: +2 vismeren, fixed Sioule spelling
- Zwemmen: Servant, Saint-Éloy-les-Mines, Vieure, Saint-Clément
- Removed: Paardrijden

## New Attractions
- Paléopolis (Gannat) - dinopark
- Klimparken - accrobranche voor alle leeftijden
- Charroux - Mooiste Dorpen van Frankrijk
- Vichy - thermale baden
- Forêt de Tronçais - grootste eikenbos van Europa