### PR TITLE
Fix family photo crop to show faces

### DIFF
--- a/src/app/wie-zijn-wij/page.tsx
+++ b/src/app/wie-zijn-wij/page.tsx
@@ -44,6 +44,7 @@ export default function WieZijnWij() {
                 alt="Paul, Marjolein, Mila en Luca"
                 fill
                 sizes="(max-width: 1024px) 100vw, 50vw"
+                className="object-top"
               />
             </div>
             <div>


### PR DESCRIPTION
Add object-top class to show the top of the photo where the faces are visible