### PR TITLE
Adjust family photo position

### DIFF
--- a/src/app/wie-zijn-wij/page.tsx
+++ b/src/app/wie-zijn-wij/page.tsx
@@ -44,7 +44,7 @@ export default function WieZijnWij() {
                 alt="Paul, Marjolein, Mila en Luca"
                 fill
                 sizes="(max-width: 1024px) 100vw, 50vw"
-                className="object-top"
+                style={{ objectPosition: "center 25%" }}
               />
             </div>
             <div>


### PR DESCRIPTION
Show photo at 25% from top instead of very top - less sky, more faces