### PR TITLE
Add 10 region photos to de-streek gallery

### DIFF
--- a/public/uploads/2024/streek/region-1.jpg
+++ b/public/uploads/2024/streek/region-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60c8acb6207b67a949c49d098c21581808912eab66222b6ec39ce78a7af237e9
+size 5353015

--- a/public/uploads/2024/streek/region-10.jpg
+++ b/public/uploads/2024/streek/region-10.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd0790d16fcda79bb7ac8b5a446d91dfc8685132511884b64b37901e59859f21
+size 6897513

--- a/public/uploads/2024/streek/region-2.jpg
+++ b/public/uploads/2024/streek/region-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a831457a9f8a6440d05d5caf290059f8d3a3c845af9c584142c5fe4429ca10f
+size 1287981

--- a/public/uploads/2024/streek/region-3.jpg
+++ b/public/uploads/2024/streek/region-3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5d7cf5a1c6c1464af7d86dce6ad38b18572c8a0b82e6686256eb6b7d400d9c5
+size 1148485

--- a/public/uploads/2024/streek/region-4.jpg
+++ b/public/uploads/2024/streek/region-4.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3b813633939bff79f8235da2c2453099a423b84bfd7a632fdcb789eff02649b
+size 6841897

--- a/public/uploads/2024/streek/region-5.jpg
+++ b/public/uploads/2024/streek/region-5.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a831457a9f8a6440d05d5caf290059f8d3a3c845af9c584142c5fe4429ca10f
+size 1287981

--- a/public/uploads/2024/streek/region-6.jpg
+++ b/public/uploads/2024/streek/region-6.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59bdbe4c64a151dc86ba524fff025c6c388e2dd69b10df2738e982def17a7e90
+size 1070148

--- a/public/uploads/2024/streek/region-7.jpg
+++ b/public/uploads/2024/streek/region-7.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:121ed8ffc5599bd2b70ebf13d4b622954505f9f7707a83372f200783bb2d2f86
+size 2179886

--- a/public/uploads/2024/streek/region-8.jpg
+++ b/public/uploads/2024/streek/region-8.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ba71f420bb152af0761b7d0d9896d64b5f0d6c5d3be07b678549c09db13ad49
+size 4549738

--- a/public/uploads/2024/streek/region-9.jpg
+++ b/public/uploads/2024/streek/region-9.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9adbe8ccd4074a2c6994c13d75c99f50bd4d3665b0128ce85fa39c5d9848c287
+size 1146683

--- a/src/app/de-streek/page.tsx
+++ b/src/app/de-streek/page.tsx
@@ -13,6 +13,16 @@ const regionImages = [
     alt: "Winter in Auvergne",
   },
   { src: "/uploads/2016/09/kanoën.jpeg", alt: "Kanoën" },
+  { src: "/uploads/2024/streek/region-1.jpg", alt: "De streek" },
+  { src: "/uploads/2024/streek/region-2.jpg", alt: "De streek" },
+  { src: "/uploads/2024/streek/region-3.jpg", alt: "De streek" },
+  { src: "/uploads/2024/streek/region-4.jpg", alt: "De streek" },
+  { src: "/uploads/2024/streek/region-5.jpg", alt: "De streek" },
+  { src: "/uploads/2024/streek/region-6.jpg", alt: "De streek" },
+  { src: "/uploads/2024/streek/region-7.jpg", alt: "De streek" },
+  { src: "/uploads/2024/streek/region-8.jpg", alt: "De streek" },
+  { src: "/uploads/2024/streek/region-9.jpg", alt: "De streek" },
+  { src: "/uploads/2024/streek/region-10.jpg", alt: "De streek" },
 ];
 
 export default function DeStreek() {


### PR DESCRIPTION
## Summary
- Adds 10 new photos from issue #64 to the region impressions gallery
- Expands the gallery from 4 to 14 photos showcasing the beautiful Auvergne surroundings
- Photos include landscapes, nature scenes, and regional attractions

Closes #64