### PR TITLE
Clarify rates page details with original style text

### DIFF
--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -255,12 +255,12 @@
       "longere": {
         "name": "La Longère (gîte)",
         "price": "à partir de 80€/nuit",
-        "details": "2p: 80€/nuit, 560€/sem (basse 500€) | 3p: 120€/nuit, 735€/sem (basse 600€) | 4p: 160€/nuit, 885€/sem (basse 700€) | 5-6p: 200-240€/nuit, 1000€/sem. Hors pellets pour chauffage."
+        "details": "2-7 personnes, salle de bain privée, 40€ par personne supplémentaire"
       },
       "chezMarco": {
         "name": "Chez Marco",
         "price": "80,00 € / 140,00 €",
-        "details": "80€ (1 chambre) ou 140€ (2 chambres), jusqu'à 6 personnes"
+        "details": "Jusqu'à 6 personnes, petit-déjeuner inclus, salle de bain privée"
       },
       "smallCaravan": {
         "name": "Petite caravane",
@@ -280,7 +280,7 @@
       "mainRoom": {
         "name": "Chambre Rouge",
         "price": "75,00 €",
-        "details": "2 personnes, salle de bain privée"
+        "details": "2 personnes, petit-déjeuner inclus, rez-de-chaussée avec douche/toilette privée"
       }
     },
     "tableTitle": "Table d'Hôtes (Repas)",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -255,12 +255,12 @@
       "longere": {
         "name": "La Longère (gîte)",
         "price": "vanaf €80/nacht",
-        "details": "2p: €80/nacht, €560/week (laag €500) | 3p: €120/nacht, €735/week (laag €600) | 4p: €160/nacht, €885/week (laag €700) | 5-6p: €200-240/nacht, €1000/week. Excl. pellets voor verwarming."
+        "details": "2-7 personen, eigen badkamer, €40 per extra persoon"
       },
       "chezMarco": {
         "name": "Chez Marco",
         "price": "€80,00 / €140,00",
-        "details": "€80 (1 kamer) of €140 (2 kamers), tot 6 personen"
+        "details": "Tot 6 personen, incl. ontbijt, eigen badkamer"
       },
       "smallCaravan": {
         "name": "Kleine caravan",
@@ -280,7 +280,7 @@
       "mainRoom": {
         "name": "Rode Kamer",
         "price": "€75,00",
-        "details": "2 personen, eigen badkamer"
+        "details": "2 personen, incl. ontbijt, begane grond met eigen douche/toilet"
       }
     },
     "tableTitle": "Table d'Hôtes (Maaltijden)",


### PR DESCRIPTION
## Summary
- Update chambres d'hôtes details to be clearer and more readable
- Uses the simpler, clearer style from the original website
- Keeps current prices

### Changes:
| Accommodation | Old Details | New Details |
|--------------|-------------|-------------|
| La Longère | Complex pricing tiers | "2-7 personen, eigen badkamer, €40 per extra persoon" |
| Chez Marco | "€80 (1 kamer) of €140 (2 kamers), tot 6 personen" | "Tot 6 personen, incl. ontbijt, eigen badkamer" |
| Rode Kamer | "2 personen, eigen badkamer" | "2 personen, incl. ontbijt, begane grond met eigen douche/toilet" |

Updates both Dutch and French translations.