### PR TITLE
Remove duplicate photos from region gallery

### DIFF
--- a/public/uploads/2024/streek/region-5.jpg
+++ b/public/uploads/2024/streek/region-5.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3a831457a9f8a6440d05d5caf290059f8d3a3c845af9c584142c5fe4429ca10f
-size 1287981

--- a/public/uploads/2024/streek/region-8.jpg
+++ b/public/uploads/2024/streek/region-8.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ba71f420bb152af0761b7d0d9896d64b5f0d6c5d3be07b678549c09db13ad49
-size 4549738

--- a/src/app/de-streek/page.tsx
+++ b/src/app/de-streek/page.tsx
@@ -17,10 +17,8 @@ const regionImages = [
   { src: "/uploads/2024/streek/region-2.jpg", alt: "De streek" },
   { src: "/uploads/2024/streek/region-3.jpg", alt: "De streek" },
   { src: "/uploads/2024/streek/region-4.jpg", alt: "De streek" },
-  { src: "/uploads/2024/streek/region-5.jpg", alt: "De streek" },
   { src: "/uploads/2024/streek/region-6.jpg", alt: "De streek" },
   { src: "/uploads/2024/streek/region-7.jpg", alt: "De streek" },
-  { src: "/uploads/2024/streek/region-8.jpg", alt: "De streek" },
   { src: "/uploads/2024/streek/region-9.jpg", alt: "De streek" },
   { src: "/uploads/2024/streek/region-10.jpg", alt: "De streek" },
 ];


### PR DESCRIPTION
## Summary
- Remove photos 9 and 12 from the region gallery (duplicates)
- Deleted: region-5.jpg and region-8.jpg
- Gallery now has 12 photos instead of 14