### PR TITLE
Replace gîte sign photo with new image

### DIFF
--- a/public/uploads/2024/gite-sign.jpg
+++ b/public/uploads/2024/gite-sign.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:27aa4be83c12d35524d13003d6c178428de2ef6abd21dd69db6293e3c39b1859
-size 331644
+oid sha256:c61670ddcae11a27792aa87b8541ab01c40a1796662864b3e297c72df61fefbe
+size 790729


### PR DESCRIPTION
## Summary
- Replace the small Résidence de Tourisme sign with a nicer photo
- As requested by Paul in issue #70

Closes #70