### PR TITLE
Add accommodation photos and Table d'hôtes section

### DIFF
--- a/public/uploads/2026/01/bergerie-1.jpg
+++ b/public/uploads/2026/01/bergerie-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:684cbd5fba34010028d1258aa93ea110687f96bebf0f3004ff625a7c6359a258
+size 1072926

--- a/public/uploads/2026/01/bergerie-2.jpg
+++ b/public/uploads/2026/01/bergerie-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:751e551954fa474c8c8d6d35967ad9259481b2670764a01de78768e33c4e9feb
+size 310517

--- a/public/uploads/2026/01/camping-1.jpg
+++ b/public/uploads/2026/01/camping-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe15a536cc10a353e34793fe6a19c50f02d679400ac015eaae290785a440b746
+size 6976356

--- a/public/uploads/2026/01/camping-2.jpg
+++ b/public/uploads/2026/01/camping-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c695eb74ec021984d9462bb8ae9635ac7935d8c2bc7a78368d7c517ebb61452
+size 3813704

--- a/public/uploads/2026/01/camping-3.jpg
+++ b/public/uploads/2026/01/camping-3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87d468e9a9df0419568c3eca7aa3d2bbfc8fd8405f35276f2b62103e58dec775
+size 859472

--- a/public/uploads/2026/01/chambres-dhotes.jpg
+++ b/public/uploads/2026/01/chambres-dhotes.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b08bf4f222ac6c2ce1fc8080477384e8c214ef41569056363bf85685679deeb1
+size 283961

--- a/public/uploads/2026/01/chez-marco-1.jpg
+++ b/public/uploads/2026/01/chez-marco-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f5b6b4aef7243ececfbbab0db914028850c4164dd115f609feaeb6f3e093a66
+size 499806

--- a/public/uploads/2026/01/chez-marco-2.jpg
+++ b/public/uploads/2026/01/chez-marco-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93b5a61a7a8fb644005c8fef56a1fe52cbdfae5f420340f6db1af50d7d1b7fa0
+size 5833099

--- a/public/uploads/2026/01/chez-marco-3.jpg
+++ b/public/uploads/2026/01/chez-marco-3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba0c239f96ae9d26856bfa931e06707a62518c773ad98c18f775f0405b69e260
+size 223995

--- a/public/uploads/2026/01/longere-1.jpg
+++ b/public/uploads/2026/01/longere-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4d635f9b454991c4d1aa1d472976e9fa628c3f0811feed4c8198f3171d49866
+size 3035988

--- a/public/uploads/2026/01/longere-2.jpg
+++ b/public/uploads/2026/01/longere-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ef6ae670346edafacd596d0e0406de5514beab2700a67d6273240eac73b49bf
+size 3120696

--- a/public/uploads/2026/01/longere-3.jpg
+++ b/public/uploads/2026/01/longere-3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e172dc05800dd08f3d5d2dffb45e15320de0e7e2c00fff9a8d4ac6391387f61c
+size 3032670

--- a/public/uploads/2026/01/longere-4.jpg
+++ b/public/uploads/2026/01/longere-4.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c79fb46196fac5f14116a9d8ef70a36a79d3f1e60bee87b61ddb2d0dfb39f1f
+size 236377

--- a/public/uploads/2026/01/longere-5.jpg
+++ b/public/uploads/2026/01/longere-5.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1abf22e5f00f678dc095489400cfbd544e7e7ccdca4140fecf7c0ff008d2ba6
+size 665262

--- a/public/uploads/2026/01/rode-bordje.jpg
+++ b/public/uploads/2026/01/rode-bordje.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c61670ddcae11a27792aa87b8541ab01c40a1796662864b3e297c72df61fefbe
+size 790729

--- a/public/uploads/2026/01/rode-kamer-1.jpg
+++ b/public/uploads/2026/01/rode-kamer-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ab2e6c783bc9eef18846fbefa6f224afb1a3107389eeeba818295260f38867a
+size 297850

--- a/public/uploads/2026/01/table-dhotes.jpg
+++ b/public/uploads/2026/01/table-dhotes.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59bdbe4c64a151dc86ba524fff025c6c388e2dd69b10df2738e982def17a7e90
+size 1070148

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,13 +33,13 @@ export default function Home() {
     {
       title: t.home.highlights.chambres.title,
       description: t.home.highlights.chambres.description,
-      image: "/uploads/2016/09/Rode-kamer.jpg",
+      image: "/uploads/2026/01/chambres-dhotes.jpg",
       href: "/wat-te-verwachten",
     },
     {
       title: t.home.highlights.table.title,
       description: t.home.highlights.table.description,
-      image: "/uploads/2020/07/proost.jpg",
+      image: "/uploads/2026/01/table-dhotes.jpg",
       href: "/tarieven",
     },
   ];
@@ -86,6 +86,68 @@ export default function Home() {
                 <Card {...item} />
               </FadeIn>
             ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Table d'Hôtes Section */}
+      <section className="py-20 md:py-28 bg-white">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
+            <FadeIn direction="left">
+              <div className="relative h-80 lg:h-[500px] rounded-2xl overflow-hidden shadow-xl">
+                <OptimizedImage
+                  src="/uploads/2026/01/table-dhotes.jpg"
+                  alt="Table d'Hôtes"
+                  fill
+                  className="hover:scale-105 transition-transform duration-700"
+                  sizes="(max-width: 1024px) 100vw, 50vw"
+                />
+              </div>
+            </FadeIn>
+            <FadeIn direction="right">
+              <div>
+                <h2 className="text-3xl md:text-4xl font-bold text-[#5C5840] mb-6 heading-decorated">
+                  {t.home.tableSection.title}
+                </h2>
+                <p className="text-lg text-gray-600 mb-4 leading-relaxed">
+                  {t.home.tableSection.intro}
+                </p>
+                <p className="text-lg text-gray-600 mb-6 leading-relaxed">
+                  {t.home.tableSection.description}
+                </p>
+                <div className="bg-[#f8f7f2] p-6 rounded-xl mb-6">
+                  <h3 className="font-semibold text-[#5C5840] mb-3">
+                    {t.home.tableSection.included}:
+                  </h3>
+                  <ul className="grid grid-cols-2 gap-2 mb-4">
+                    {t.home.tableSection.includedItems.map((item, index) => (
+                      <li key={index} className="flex items-center gap-2 text-gray-600">
+                        <span className="text-amber-600">✓</span> {item}
+                      </li>
+                    ))}
+                  </ul>
+                  <p className="text-2xl font-bold text-amber-700 mb-2">
+                    {t.home.tableSection.price}
+                  </p>
+                  <p className="text-sm text-gray-500">
+                    {t.home.tableSection.extras}
+                  </p>
+                </div>
+                <p className="text-gray-600 mb-2 italic">
+                  {t.home.tableSection.note}
+                </p>
+                <p className="text-amber-700 font-medium">
+                  {t.home.tableSection.kids}
+                </p>
+                <Link
+                  href="/tarieven"
+                  className="inline-block mt-6 px-6 py-3 bg-[#5C5840] text-white font-semibold rounded-lg hover:bg-[#4a4833] transition-colors"
+                >
+                  {t.common.viewRates}
+                </Link>
+              </div>
+            </FadeIn>
           </div>
         </div>
       </section>

--- a/src/app/tarieven/page.tsx
+++ b/src/app/tarieven/page.tsx
@@ -196,10 +196,10 @@ export default function Tarieven() {
                 </tr>
                 <tr className="hover:bg-amber-50">
                   <td className="px-6 py-4">
-                    {t.rates.tableItems.lunch.description}
+                    {t.rates.tableItems.kids.description}
                   </td>
                   <td className="px-6 py-4 text-right font-semibold text-amber-700">
-                    {t.rates.tableItems.lunch.price}
+                    {t.rates.tableItems.kids.price}
                   </td>
                 </tr>
                 <tr className="hover:bg-amber-50">

--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -1,29 +1,42 @@
 "use client";
 
 import Hero from "@/components/Hero";
+import ImageGallery from "@/components/ImageGallery";
 import OptimizedImage from "@/components/OptimizedImage";
 import { useTranslation } from "@/i18n";
 
+const longereImages = [
+  { src: "/uploads/2026/01/longere-1.jpg", alt: "La Longère interieur" },
+  { src: "/uploads/2026/01/longere-2.jpg", alt: "La Longère slaapkamer" },
+  { src: "/uploads/2026/01/longere-3.jpg", alt: "La Longère keuken" },
+  { src: "/uploads/2026/01/longere-4.jpg", alt: "La Longère woonkamer" },
+  { src: "/uploads/2026/01/longere-5.jpg", alt: "La Longère badkamer" },
+];
+
+const chezMarcoImages = [
+  { src: "/uploads/2026/01/chez-marco-1.jpg", alt: "Chez Marco slaapkamer" },
+  { src: "/uploads/2026/01/chez-marco-2.jpg", alt: "Chez Marco interieur" },
+  { src: "/uploads/2026/01/chez-marco-3.jpg", alt: "Chez Marco woonkamer" },
+];
+
+const rodeKamerImages = [
+  { src: "/uploads/2026/01/rode-kamer-1.jpg", alt: "Rode Kamer" },
+];
+
+const bergerieImages = [
+  { src: "/uploads/2026/01/bergerie-1.jpg", alt: "La Bergerie interieur" },
+  { src: "/uploads/2026/01/bergerie-2.jpg", alt: "La Bergerie exterieur" },
+];
+
+const campingImages = [
+  { src: "/uploads/2020/07/camping-2.jpg", alt: "Camping met tent" },
+  { src: "/uploads/2026/01/camping-1.jpg", alt: "Camping terrein" },
+  { src: "/uploads/2026/01/camping-2.jpg", alt: "Camping uitzicht" },
+  { src: "/uploads/2026/01/camping-3.jpg", alt: "Camping omgeving" },
+];
+
 export default function WatTeVerwachten() {
   const { t } = useTranslation();
-
-  const rooms = [
-    {
-      name: t.whatToExpect.rooms.longere.name,
-      capacity: t.whatToExpect.rooms.longere.capacity,
-      description: t.whatToExpect.rooms.longere.description,
-    },
-    {
-      name: t.whatToExpect.rooms.chezMarco.name,
-      capacity: t.whatToExpect.rooms.chezMarco.capacity,
-      description: t.whatToExpect.rooms.chezMarco.description,
-    },
-    {
-      name: t.whatToExpect.rooms.red.name,
-      capacity: t.whatToExpect.rooms.red.capacity,
-      description: t.whatToExpect.rooms.red.description,
-    },
-  ];
 
   return (
     <>
@@ -42,104 +55,141 @@ export default function WatTeVerwachten() {
         </div>
       </section>
 
-      {/* Rooms */}
+      {/* Chambres Title with Gîte Sign */}
       <section className="py-16 bg-amber-50">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex flex-col items-center mb-12">
             <h2 className="text-3xl font-bold text-amber-900 text-center mb-4">
               {t.whatToExpect.chambresTitle}
             </h2>
-            <div className="relative h-24 w-32">
+            <div className="relative h-48 w-64">
               <OptimizedImage
                 src="/uploads/2024/gite-sign.jpg"
                 alt="Officieel Gîte de France"
                 fill
                 className="object-contain"
-                sizes="128px"
+                sizes="256px"
               />
             </div>
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-            {rooms.map((room) => (
-              <div key={room.name} className="bg-white p-6 rounded-xl shadow-sm">
-                <h3 className="text-xl font-semibold text-amber-800 mb-2">
-                  {room.name}
-                </h3>
-                <p className="text-amber-600 font-medium mb-2">{room.capacity}</p>
-                <p className="text-gray-600">{room.description}</p>
-              </div>
-            ))}
+        </div>
+      </section>
+
+      {/* La Longère */}
+      <section className="py-16 bg-white">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="mb-8">
+            <h3 className="text-2xl font-semibold text-amber-800 mb-2">
+              {t.whatToExpect.rooms.longere.name}
+            </h3>
+            <p className="text-amber-600 font-medium mb-2">
+              {t.whatToExpect.rooms.longere.capacity}
+            </p>
+            <p className="text-gray-600 mb-6">
+              {t.whatToExpect.rooms.longere.description}
+            </p>
           </div>
+          <ImageGallery images={longereImages} />
+        </div>
+      </section>
+
+      {/* Chez Marco */}
+      <section className="py-16 bg-amber-50">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="mb-8">
+            <h3 className="text-2xl font-semibold text-amber-800 mb-2">
+              {t.whatToExpect.rooms.chezMarco.name}
+            </h3>
+            <p className="text-amber-600 font-medium mb-2">
+              {t.whatToExpect.rooms.chezMarco.capacity}
+            </p>
+            <p className="text-gray-600 mb-6">
+              {t.whatToExpect.rooms.chezMarco.description}
+            </p>
+          </div>
+          <ImageGallery images={chezMarcoImages} />
+        </div>
+      </section>
+
+      {/* Rode Kamer */}
+      <section className="py-16 bg-white">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="mb-8">
+            <h3 className="text-2xl font-semibold text-amber-800 mb-2">
+              {t.whatToExpect.rooms.red.name}
+            </h3>
+            <p className="text-amber-600 font-medium mb-2">
+              {t.whatToExpect.rooms.red.capacity}
+            </p>
+            <p className="text-gray-600 mb-6">
+              {t.whatToExpect.rooms.red.description}
+            </p>
+          </div>
+          <ImageGallery images={rodeKamerImages} />
         </div>
       </section>
 
       {/* Camping */}
-      <section className="py-16 bg-white">
+      <section className="py-16 bg-amber-50">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-            <div>
-              <h2 className="text-3xl font-bold text-amber-900 mb-6">
-                {t.whatToExpect.campingTitle}
-              </h2>
-              <p className="text-lg text-gray-600 mb-4">
-                {t.whatToExpect.campingText}
-              </p>
-              <ul className="space-y-3 text-gray-600">
-                <li className="flex items-start gap-2">
-                  <span className="text-amber-600">✓</span>
-                  {t.whatToExpect.campingFeatures.electricity}
-                </li>
-                <li className="flex items-start gap-2">
-                  <span className="text-amber-600">✓</span>
-                  {t.whatToExpect.campingFeatures.dogs}
-                </li>
-                <li className="flex items-start gap-2">
-                  <span className="text-amber-600">✓</span>
-                  {t.whatToExpect.campingFeatures.quiet}
-                </li>
-                <li className="flex items-start gap-2">
-                  <span className="text-amber-600">✓</span>
-                  {t.whatToExpect.campingFeatures.sanitary}
-                </li>
-              </ul>
-            </div>
-            <div className="relative h-80 rounded-xl overflow-hidden shadow-lg">
-              <OptimizedImage
-                src="/uploads/2020/07/camping-2.jpg"
-                alt="Camping"
-                fill
-                sizes="(max-width: 1024px) 100vw, 50vw"
-              />
-            </div>
+          <div className="mb-8">
+            <h2 className="text-3xl font-bold text-amber-900 mb-6">
+              {t.whatToExpect.campingTitle}
+            </h2>
+            <p className="text-lg text-gray-600 mb-4">
+              {t.whatToExpect.campingText}
+            </p>
+            <ul className="space-y-3 text-gray-600 mb-6">
+              <li className="flex items-start gap-2">
+                <span className="text-amber-600">✓</span>
+                {t.whatToExpect.campingFeatures.electricity}
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-amber-600">✓</span>
+                {t.whatToExpect.campingFeatures.dogs}
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-amber-600">✓</span>
+                {t.whatToExpect.campingFeatures.quiet}
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-amber-600">✓</span>
+                {t.whatToExpect.campingFeatures.sanitary}
+              </li>
+            </ul>
           </div>
+          <ImageGallery images={campingImages} />
         </div>
       </section>
 
       {/* Additional Accommodations */}
-      <section className="py-16 bg-amber-50">
+      <section className="py-16 bg-white">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-amber-900 text-center mb-12">
             {t.whatToExpect.additionalTitle}
           </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-            <div className="bg-white p-8 rounded-xl shadow-sm">
-              <h3 className="text-2xl font-semibold text-amber-800 mb-4">
-                {t.whatToExpect.caravan.title}
-              </h3>
-              <p className="text-gray-600 mb-4">{t.whatToExpect.caravan.text}</p>
-              <p className="text-amber-600 font-medium">
-                {t.whatToExpect.caravan.note}
-              </p>
-            </div>
-            <div className="bg-white p-8 rounded-xl shadow-sm">
-              <h3 className="text-2xl font-semibold text-amber-800 mb-4">
-                {t.whatToExpect.bergerie.title}
-              </h3>
-              <p className="text-gray-600 mb-4">{t.whatToExpect.bergerie.text}</p>
-              <p className="text-amber-600 font-medium">
-                {t.whatToExpect.bergerie.note}
-              </p>
-            </div>
+
+          {/* Kleine Caravan */}
+          <div className="bg-amber-50 p-8 rounded-xl shadow-sm mb-8">
+            <h3 className="text-2xl font-semibold text-amber-800 mb-4">
+              {t.whatToExpect.caravan.title}
+            </h3>
+            <p className="text-gray-600 mb-4">{t.whatToExpect.caravan.text}</p>
+            <p className="text-amber-600 font-medium">
+              {t.whatToExpect.caravan.note}
+            </p>
+          </div>
+
+          {/* La Bergerie */}
+          <div className="mb-8">
+            <h3 className="text-2xl font-semibold text-amber-800 mb-4">
+              {t.whatToExpect.bergerie.title}
+            </h3>
+            <p className="text-gray-600 mb-4">{t.whatToExpect.bergerie.text}</p>
+            <p className="text-amber-600 font-medium mb-6">
+              {t.whatToExpect.bergerie.note}
+            </p>
+            <ImageGallery images={bergerieImages} />
           </div>
         </div>
       </section>

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -38,6 +38,17 @@
     "whyTheNameText1": "Le nom \"Les Deux Chevaux\" fait référence à l'emblématique voiture française, la Citroën 2CV - soit \"deux chevaux\" (deux chevaux-vapeur).",
     "whyTheNameText2": "Cette voiture symbolise la vie détendue et authentique de la campagne française que nous souhaitons offrir à nos hôtes.",
     "impressions": "Impressions",
+    "tableSection": {
+      "title": "Table d'Hôtes",
+      "intro": "La table d'hôtes comme elle devrait être. Manger ensemble à la grande table, un verre de vin, de bonnes conversations. Étrangers au début de la soirée, amis à la fin. Exactement comme les vacances devraient être. Les enfants sont aussi les bienvenus.",
+      "description": "Profitez d'un menu trois plats fait maison, ensemble à table, préparé avec des produits de saison.",
+      "included": "Inclus",
+      "includedItems": ["Entrée", "Plat principal", "Dessert", "Eau", "Un verre de vin/bière", "Café ou thé après"],
+      "price": "22,50 € p.p.",
+      "extras": "Boissons supplémentaires (bière, soft): 2,50 € le verre • Plus de vin? +2,50 € le verre",
+      "note": "Un seul menu pour tous les invités, merci de signaler les allergies à l'avance.",
+      "kids": "Enfants jusqu'à 10 ans: plat + dessert ou glace — 10,00 €"
+    },
     "readyForStay": "Prêt(e) pour votre séjour en Auvergne ?",
     "ctaText": "Contactez-nous pour plus d'informations ou pour faire une réservation.",
     "highlights": {
@@ -51,7 +62,7 @@
       },
       "table": {
         "title": "Table d'Hôtes",
-        "description": "Savourez d'authentiques repas français"
+        "description": "La table d'hôtes comme elle devrait être. Manger ensemble à la grande table, bonnes conversations. Étrangers au début, amis à la fin. Menu trois plats incl. eau, verre de vin/bière et café — 22,50€ p.p."
       }
     }
   },
@@ -287,16 +298,16 @@
     "meal": "Repas",
     "tableItems": {
       "dinner": {
-        "description": "Menu en 3 services avec café",
-        "price": "20,00 € p.p."
+        "description": "Menu 3 plats (incl. eau, verre de vin/bière, café/thé)",
+        "price": "22,50 € p.p."
       },
       "drinks": {
-        "description": "Boissons au dîner",
-        "price": "2,00 € pièce"
+        "description": "Boissons supplémentaires (bière, soft, vin)",
+        "price": "2,50 € le verre"
       },
-      "lunch": {
-        "description": "Déjeuner",
-        "price": "7,50 € p.p."
+      "kids": {
+        "description": "Enfants jusqu'à 10 ans (plat + dessert/glace)",
+        "price": "10,00 €"
       },
       "breakfast": {
         "description": "Petit-déjeuner (séparé)",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -38,6 +38,17 @@
     "whyTheNameText1": "De naam \"Les Deux Chevaux\" verwijst naar de iconische Franse auto, de Citroën 2CV - oftewel \"deux chevaux\" (twee paardenkrachten).",
     "whyTheNameText2": "Deze auto symboliseert het relaxte, authentieke Franse plattelandsleven dat wij onze gasten willen bieden.",
     "impressions": "Impressies",
+    "tableSection": {
+      "title": "Table d'Hôtes",
+      "intro": "Table d'hôtes zoals het bedoeld is. Samen eten aan de lange tafel, een glas wijn, goede gesprekken. Vreemden aan het begin van de avond, bekenden aan het einde. Precies zoals vakantie hoort te zijn. Ook kids zijn van harte welkom.",
+      "description": "Geniet van een huisgemaakt driegangenmenu, samen aan tafel, bereid met seizoensproducten.",
+      "included": "Inbegrepen",
+      "includedItems": ["Voorgerecht", "Hoofdgerecht", "Dessert", "Water", "Één glas wijn/bier", "Koffie of thee na afloop"],
+      "price": "€22,50 p.p.",
+      "extras": "Extra drankjes (bier, fris): €2,50 per glas • Meer wijn? +€2,50 per glas",
+      "note": "Eén menu voor alle gasten, allergieën graag vooraf melden.",
+      "kids": "Kinderen t/m 10 jaar: hoofdgerecht + toetje of ijsje — €10,00"
+    },
     "readyForStay": "Klaar voor uw verblijf in de Auvergne?",
     "ctaText": "Neem contact met ons op voor meer informatie of om een reservering te maken.",
     "highlights": {
@@ -51,7 +62,7 @@
       },
       "table": {
         "title": "Table d'Hôtes",
-        "description": "Geniet van authentieke Franse maaltijden"
+        "description": "Table d'hôtes zoals het bedoeld is. Samen eten aan de lange tafel, goede gesprekken. Vreemden aan het begin, bekenden aan het einde. Driegangenmenu incl. water, glas wijn/bier en koffie — €22,50 p.p."
       }
     }
   },
@@ -287,16 +298,16 @@
     "meal": "Maaltijd",
     "tableItems": {
       "dinner": {
-        "description": "Driegangen diner met koffie",
-        "price": "€20,00 p.p."
+        "description": "Driegangenmenu (incl. water, glas wijn/bier, koffie/thee)",
+        "price": "€22,50 p.p."
       },
       "drinks": {
-        "description": "Drankjes bij diner",
-        "price": "€2,00 per stuk"
+        "description": "Extra drankjes (bier, fris, wijn)",
+        "price": "€2,50 per glas"
       },
-      "lunch": {
-        "description": "Lunch",
-        "price": "€7,50 p.p."
+      "kids": {
+        "description": "Kinderen t/m 10 jaar (hoofdgerecht + toetje/ijsje)",
+        "price": "€10,00"
       },
       "breakfast": {
         "description": "Ontbijt (los)",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -40,6 +40,17 @@ export interface Translations {
     whyTheNameText1: string;
     whyTheNameText2: string;
     impressions: string;
+    tableSection: {
+      title: string;
+      intro: string;
+      description: string;
+      included: string;
+      includedItems: string[];
+      price: string;
+      extras: string;
+      note: string;
+      kids: string;
+    };
     readyForStay: string;
     ctaText: string;
     highlights: {
@@ -173,7 +184,7 @@ export interface Translations {
     tableItems: {
       dinner: { description: string; price: string };
       drinks: { description: string; price: string };
-      lunch: { description: string; price: string };
+      kids: { description: string; price: string };
       breakfast: { description: string; price: string };
     };
   };


### PR DESCRIPTION
## Summary

Addresses all requests from issue #72:

- **Photo galleries added** to Wat te Verwachten page:
  - La Longère: 5 photos
  - Chez Marco: 3 photos
  - Rode Kamer: 1 photo
  - Bergerie: 2 photos
  - Camping: 4 photos (converted to gallery section)

- **Gîte sign (rode bordje)** made 2x larger on Wat te Verwachten page

- **Homepage updates**:
  - New Chambre d'hôtes card photo
  - New Table d'hôtes card photo
  - **New dedicated Table d'hôtes section** with full pricing details:
    - €22,50 p.p. for 3-course menu
    - Includes: voorgerecht, hoofdgerecht, dessert, water, glas wijn/bier, koffie/thee
    - Extra drinks: €2,50 per glass
    - Kids (t/m 10 jaar): €10,00

- **Tarieven page** updated with new pricing

## Test plan

- [ ] Verify all galleries display correctly on Wat te Verwachten page
- [ ] Verify gîte sign is larger
- [ ] Verify new Table d'hôtes section displays on homepage
- [ ] Verify updated photos on homepage cards
- [ ] Verify pricing on Tarieven page
- [ ] Test both NL and FR translations

Closes #72