### PR TITLE
Pas prijsweergave aan voor Chez Marco en Table d'hôtes

### DIFF
--- a/src/app/tarieven/page.tsx
+++ b/src/app/tarieven/page.tsx
@@ -188,18 +188,18 @@ export default function Tarieven() {
                 </tr>
                 <tr className="hover:bg-amber-50">
                   <td className="px-6 py-4">
-                    {t.rates.tableItems.drinks.description}
-                  </td>
-                  <td className="px-6 py-4 text-right font-medium">
-                    {t.rates.tableItems.drinks.price}
-                  </td>
-                </tr>
-                <tr className="hover:bg-amber-50">
-                  <td className="px-6 py-4">
                     {t.rates.tableItems.kids.description}
                   </td>
                   <td className="px-6 py-4 text-right font-semibold text-amber-700">
                     {t.rates.tableItems.kids.price}
+                  </td>
+                </tr>
+                <tr className="hover:bg-amber-50">
+                  <td className="px-6 py-4">
+                    {t.rates.tableItems.drinks.description}
+                  </td>
+                  <td className="px-6 py-4 text-right font-medium">
+                    {t.rates.tableItems.drinks.price}
                   </td>
                 </tr>
                 <tr className="hover:bg-amber-50">

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -270,8 +270,8 @@
       },
       "chezMarco": {
         "name": "Chez Marco",
-        "price": "80,00 € / 140,00 €",
-        "details": "Jusqu'à 6 personnes, petit-déjeuner inclus, salle de bain privée"
+        "price": "à partir de 80€/nuit",
+        "details": "Jusqu'à 6 personnes, petit-déjeuner inclus, 40€ par personne supplémentaire"
       },
       "smallCaravan": {
         "name": "Petite caravane",
@@ -298,16 +298,16 @@
     "meal": "Repas",
     "tableItems": {
       "dinner": {
-        "description": "Menu 3 plats (incl. eau, verre de vin/bière, café/thé)",
+        "description": "Menu 3 plats avec 1 consommation, café et eau",
         "price": "22,50 € p.p."
       },
-      "drinks": {
-        "description": "Boissons supplémentaires (bière, soft, vin)",
-        "price": "2,50 € le verre"
-      },
       "kids": {
-        "description": "Enfants jusqu'à 10 ans (plat + dessert/glace)",
-        "price": "10,00 €"
+        "description": "Enfants jusqu'à 10 ans",
+        "price": "10,00 € p.p."
+      },
+      "drinks": {
+        "description": "Boissons",
+        "price": "2,50 €"
       },
       "breakfast": {
         "description": "Petit-déjeuner (séparé)",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -270,8 +270,8 @@
       },
       "chezMarco": {
         "name": "Chez Marco",
-        "price": "€80,00 / €140,00",
-        "details": "Tot 6 personen, incl. ontbijt, eigen badkamer"
+        "price": "vanaf €80/nacht",
+        "details": "Tot 6 personen, incl. ontbijt, €40 per extra persoon"
       },
       "smallCaravan": {
         "name": "Kleine caravan",
@@ -298,16 +298,16 @@
     "meal": "Maaltijd",
     "tableItems": {
       "dinner": {
-        "description": "Driegangenmenu (incl. water, glas wijn/bier, koffie/thee)",
+        "description": "Driegangen diner met 1 consumptie, koffie en water",
         "price": "€22,50 p.p."
       },
-      "drinks": {
-        "description": "Extra drankjes (bier, fris, wijn)",
-        "price": "€2,50 per glas"
-      },
       "kids": {
-        "description": "Kinderen t/m 10 jaar (hoofdgerecht + toetje/ijsje)",
-        "price": "€10,00"
+        "description": "Kinderen t/m 10 jaar",
+        "price": "€10,00 p.p."
+      },
+      "drinks": {
+        "description": "Drankjes",
+        "price": "€2,50"
       },
       "breakfast": {
         "description": "Ontbijt (los)",


### PR DESCRIPTION
## Samenvatting

Adresseert alle verzoeken uit issue #73:

### Punt 1: Chez Marco prijsweergave
- **Was:** €80,00 / €140,00
- **Wordt:** vanaf €80/nacht, €40 per extra persoon
- Nu consistent met La Longère weergave

### Punt 2: Table d'hôtes prijzen
- **Diner:** "Driegangen diner met 1 consumptie, koffie en water" — €22,50 p.p.
- **Kinderen t/m 10 jaar:** €10,00 p.p.
- **Drankjes:** €2,50
- Lunch rubriek verwijderd (was al gedaan in #72)

## Testplan

- [ ] Controleer Chez Marco prijs op tarieven pagina
- [ ] Controleer Table d'hôtes beschrijving en prijzen
- [ ] Controleer volgorde: diner, kinderen, drankjes, ontbijt
- [ ] Test beide NL en FR vertalingen

Closes #73