### PR TITLE
Voeg afgeronde hoeken toe aan gîte bord

### DIFF
--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -62,12 +62,12 @@ export default function WatTeVerwachten() {
             <h2 className="text-3xl font-bold text-amber-900 text-center mb-4">
               {t.whatToExpect.chambresTitle}
             </h2>
-            <div className="relative h-48 w-64">
+            <div className="relative h-48 w-64 rounded-2xl overflow-hidden shadow-lg">
               <OptimizedImage
                 src="/uploads/2024/gite-sign.jpg"
                 alt="Officieel Gîte de France"
                 fill
-                className="object-contain"
+                className="object-cover"
                 sizes="256px"
               />
             </div>


### PR DESCRIPTION
## Samenvatting

Het rode gîte bord (Résidence de Tourisme) heeft nu afgeronde hoeken, consistent met de rest van de website.

### Wijzigingen
- `rounded-2xl` toegevoegd voor afgeronde hoeken
- `overflow-hidden` voor correcte clipping
- `shadow-lg` voor subtiele schaduw
- `object-cover` voor betere weergave

## Testplan
- [ ] Controleer gîte bord op "Wat te verwachten" pagina
- [ ] Vergelijk met andere afbeeldingen op de site