### PR TITLE
Gîte toevoegen aan hero/welkom en ontbijt verwijderen bij Chez Marco

### DIFF
--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -29,9 +29,9 @@
     "free": "Gratuit"
   },
   "home": {
-    "heroSubtitle": "Mini-camping, chambres d'hôtes et table d'hôtes en Auvergne",
+    "heroSubtitle": "Gîte, mini-camping, chambres d'hôtes et table d'hôtes en Auvergne",
     "welcomeTitle": "Bienvenue en Auvergne",
-    "welcomeText1": "Bienvenue sur le site de Les Deux Chevaux, un mini-camping convivial, chambres d'hôtes (Bed & Breakfast) et table d'hôtes dans la magnifique Auvergne, France.",
+    "welcomeText1": "Bienvenue sur le site de Les Deux Chevaux, un gîte ensoleillé, un mini-camping convivial, chambres d'hôtes (Bed & Breakfast) et table d'hôtes dans la magnifique Auvergne, France.",
     "welcomeText2": "Nous, Yvonne et Rob, vous souhaitons la bienvenue dans notre petit coin de paradis au cœur de la France.",
     "whatWeOffer": "Que proposons-nous ?",
     "whyTheName": "Pourquoi \"Les Deux Chevaux\" ?",
@@ -271,7 +271,7 @@
       "chezMarco": {
         "name": "Chez Marco",
         "price": "à partir de 80€/nuit",
-        "details": "Jusqu'à 6 personnes, petit-déjeuner inclus, 40€ par personne supplémentaire"
+        "details": "Jusqu'à 6 personnes, 40€ par personne supplémentaire"
       },
       "smallCaravan": {
         "name": "Petite caravane",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -29,9 +29,9 @@
     "free": "Gratis"
   },
   "home": {
-    "heroSubtitle": "Mini-camping, chambres d'hôtes en table d'hôtes in de Auvergne",
+    "heroSubtitle": "Gîte, mini-camping, chambres d'hôtes en table d'hôtes in de Auvergne",
     "welcomeTitle": "Welkom in de Auvergne",
-    "welcomeText1": "Welkom op de website van Les Deux Chevaux, een gezellige mini-camping, chambres d'hôtes (Bed & Breakfast) en table d'hôtes in het prachtige Auvergne, Frankrijk.",
+    "welcomeText1": "Welkom op de website van Les Deux Chevaux, een zonnige gîte, een gezellige mini-camping, chambres d'hôtes (Bed & Breakfast) en table d'hôtes in het prachtige Auvergne, Frankrijk.",
     "welcomeText2": "Wij, Yvonne en Rob, heten u van harte welkom op ons stukje paradijs in het hartje van Frankrijk.",
     "whatWeOffer": "Wat bieden wij?",
     "whyTheName": "Waarom \"Les Deux Chevaux\"?",
@@ -271,7 +271,7 @@
       "chezMarco": {
         "name": "Chez Marco",
         "price": "vanaf €80/nacht",
-        "details": "Tot 6 personen, incl. ontbijt, €40 per extra persoon"
+        "details": "Tot 6 personen, €40 per extra persoon"
       },
       "smallCaravan": {
         "name": "Kleine caravan",


### PR DESCRIPTION
## Samenvatting
Wijzigingen op verzoek van Yvonne:

- **heroSubtitle**: "Gîte" toegevoegd aan begin ("Gîte, mini-camping, chambres d'hôtes...")
- **welcomeText1**: "een zonnige gîte" toegevoegd  
- **Chez Marco**: "incl. ontbijt" verwijderd (ontbijt niet altijd inbegrepen)

Wijzigingen doorgevoerd in zowel Nederlands als Frans.

## Testplan
- [x] Build succesvol
- [ ] Controleer homepage hero tekst
- [ ] Controleer welkomsttekst  
- [ ] Controleer tarieven pagina Chez Marco