### PR TITLE
Wijzig Chambres d'Hôtes naar Gîte / Chambres d'Hôtes

### DIFF
--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -57,8 +57,8 @@
         "description": "6 emplacements spacieux pour tente ou caravane dans une ambiance détendue"
       },
       "chambres": {
-        "title": "Chambres d'Hôtes",
-        "description": "Chambres confortables avec délicieux petit-déjeuner français"
+        "title": "Gîte / Chambres d'Hôtes",
+        "description": "Chambre confortable ou une maison entière pour vous"
       },
       "table": {
         "title": "Table d'Hôtes",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -57,8 +57,8 @@
         "description": "6 ruime plekken voor tent of caravan in een ontspannen sfeer"
       },
       "chambres": {
-        "title": "Chambres d'Hôtes",
-        "description": "Comfortabele kamers met heerlijk Frans ontbijt"
+        "title": "Gîte / Chambres d'Hôtes",
+        "description": "Comfortabele kamer of een heel huis voor jezelf"
       },
       "table": {
         "title": "Table d'Hôtes",


### PR DESCRIPTION
## Samenvatting
Bij 'Wat bieden wij?' op homepage:
- Titel: "Chambres d'Hôtes" → "Gîte / Chambres d'Hôtes"
- Tekst: "Comfortabele kamer of een heel huis voor jezelf"

NL & FR bijgewerkt.