### PR TITLE
Fix: verwijder basePath voor custom domain

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,8 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "export",
-  basePath: "/lesdeuxchevaux",
-  assetPrefix: "/lesdeuxchevaux",
   images: {
     loader: "custom",
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],


### PR DESCRIPTION
basePath en assetPrefix verwijderd - niet nodig met custom domain lesdeuxchevaux.nl