### PR TITLE
Add English as third language

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -135,7 +135,7 @@ export default function Contact() {
                       rel="noopener noreferrer"
                       className="text-green-600 hover:text-green-700 transition-colors"
                     >
-                      {locale === "nl" ? "Stuur een bericht" : "Envoyer un message"}
+                      {locale === "nl" ? "Stuur een bericht" : locale === "fr" ? "Envoyer un message" : "Send a message"}
                     </a>
                   </div>
                 </div>

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -4,8 +4,8 @@ import { useState } from "react";
 import { useTranslation } from "@/i18n";
 
 interface FAQItem {
-  question: { nl: string; fr: string };
-  answer: { nl: string; fr: string };
+  question: { nl: string; fr: string; en: string };
+  answer: { nl: string; fr: string; en: string };
 }
 
 const faqItems: FAQItem[] = [
@@ -13,50 +13,60 @@ const faqItems: FAQItem[] = [
     question: {
       nl: "Zijn honden welkom?",
       fr: "Les chiens sont-ils les bienvenus ?",
+      en: "Are dogs welcome?",
     },
     answer: {
       nl: "Ja, honden zijn welkom op de camping (aangelijnd). Ze zijn gratis!",
       fr: "Oui, les chiens sont les bienvenus au camping (tenus en laisse). C'est gratuit !",
+      en: "Yes, dogs are welcome at the campsite (on a leash). They're free!",
     },
   },
   {
     question: {
       nl: "Is er WiFi beschikbaar?",
       fr: "Y a-t-il du WiFi disponible ?",
+      en: "Is WiFi available?",
     },
     answer: {
       nl: "Ja, we hebben uitstekende WiFi via Starlink in en rond het huis. Op de camping is geen WiFi beschikbaar - daar kun je echt even ontspannen!",
       fr: "Oui, nous avons un excellent WiFi via Starlink dans et autour de la maison. Il n'y a pas de WiFi au camping - là-bas, vous pouvez vraiment vous détendre !",
+      en: "Yes, we have excellent WiFi via Starlink in and around the house. There's no WiFi at the campsite - there you can truly relax!",
     },
   },
   {
     question: {
       nl: "Wat zijn de check-in en check-out tijden?",
       fr: "Quelles sont les heures d'arrivée et de départ ?",
+      en: "What are the check-in and check-out times?",
     },
     answer: {
       nl: "Check-in is vanaf 15:00 uur, check-out vóór 11:00 uur. Flexibele tijden zijn mogelijk in overleg.",
       fr: "L'arrivée est à partir de 15h00, le départ avant 11h00. Des horaires flexibles sont possibles sur demande.",
+      en: "Check-in is from 3:00 PM, check-out before 11:00 AM. Flexible times are possible upon request.",
     },
   },
   {
     question: {
       nl: "Moet ik de table d'hôtes van tevoren reserveren?",
       fr: "Dois-je réserver la table d'hôtes à l'avance ?",
+      en: "Do I need to book the table d'hôtes in advance?",
     },
     answer: {
       nl: "Ja, graag minimaal een dag van tevoren zodat we verse ingrediënten kunnen inkopen.",
       fr: "Oui, veuillez réserver au moins un jour à l'avance afin que nous puissions acheter des ingrédients frais.",
+      en: "Yes, please book at least one day in advance so we can purchase fresh ingredients.",
     },
   },
   {
     question: {
       nl: "Welke betaalmethoden accepteren jullie?",
       fr: "Quels modes de paiement acceptez-vous ?",
+      en: "What payment methods do you accept?",
     },
     answer: {
       nl: "We accepteren zowel pinbetalingen (via Sumup) als contant geld.",
       fr: "Nous acceptons les paiements par carte (via Sumup) ainsi que les espèces.",
+      en: "We accept both card payments (via Sumup) and cash.",
     },
   },
 ];
@@ -65,7 +75,7 @@ export default function FAQ() {
   const { locale } = useTranslation();
   const [openIndex, setOpenIndex] = useState<number | null>(null);
 
-  const title = locale === "nl" ? "Veelgestelde vragen" : "Questions fréquentes";
+  const title = locale === "nl" ? "Veelgestelde vragen" : locale === "fr" ? "Questions fréquentes" : "Frequently Asked Questions";
 
   return (
     <section className="py-16 bg-white">

--- a/src/components/LanguageToggle.tsx
+++ b/src/components/LanguageToggle.tsx
@@ -1,33 +1,37 @@
 "use client";
 
 import { useTranslation } from "@/i18n";
+import type { Locale } from "@/i18n";
+
+const languages: { code: Locale; label: string }[] = [
+  { code: "nl", label: "NL" },
+  { code: "fr", label: "FR" },
+  { code: "en", label: "EN" },
+];
 
 export default function LanguageToggle() {
   const { locale, setLocale } = useTranslation();
 
-  const toggleLanguage = () => {
-    setLocale(locale === "nl" ? "fr" : "nl");
-  };
-
   return (
-    <button
-      onClick={toggleLanguage}
-      className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-[#6E6A4A] hover:bg-[#5C5840] transition-colors text-sm font-medium"
-      aria-label={
-        locale === "nl" ? "Changer en français" : "Overschakelen naar Nederlands"
-      }
-    >
-      <span
-        className={`transition-opacity ${locale === "nl" ? "text-white" : "text-[#D4C9A8]"}`}
-      >
-        NL
-      </span>
-      <span className="text-[#A09B7D]">/</span>
-      <span
-        className={`transition-opacity ${locale === "fr" ? "text-white" : "text-[#D4C9A8]"}`}
-      >
-        FR
-      </span>
-    </button>
+    <div className="flex items-center gap-1 px-2 py-1 rounded-full bg-[#6E6A4A]">
+      {languages.map((lang, index) => (
+        <span key={lang.code} className="flex items-center">
+          <button
+            onClick={() => setLocale(lang.code)}
+            className={`px-2 py-0.5 text-sm font-medium transition-colors rounded ${
+              locale === lang.code
+                ? "text-white"
+                : "text-[#D4C9A8] hover:text-white"
+            }`}
+            aria-label={`Switch to ${lang.label}`}
+          >
+            {lang.label}
+          </button>
+          {index < languages.length - 1 && (
+            <span className="text-[#A09B7D] mx-0.5">/</span>
+          )}
+        </span>
+      ))}
+    </div>
   );
 }

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -8,6 +8,7 @@ interface Review {
   text: {
     nl: string;
     fr: string;
+    en: string;
   };
   date: string;
 }
@@ -19,6 +20,7 @@ const reviews: Review[] = [
     text: {
       nl: "Echt een aanrader! Op onze terugreis vanuit de Ardeche naar Nederland zijn wij heel gastvrij ontvangen en hebben twee nachtjes geslapen in de longère. Een heerlijk huis, alles is aanwezig en vooral erg netjes en schoon. Table d'hôtes, dat hadden wij nog niet eerder meegemaakt... het was heerlijk! Rob (en zijn zoon) kunnen fantastisch koken. Wij komen graag nog een keer terug!",
       fr: "Vraiment recommandé ! Lors de notre voyage retour de l'Ardèche vers les Pays-Bas, nous avons été accueillis très chaleureusement et avons passé deux nuits dans la longère. Une maison merveilleuse, tout est présent et surtout très propre. Table d'hôtes, nous n'avions jamais essayé... c'était délicieux ! Rob (et son fils) cuisinent fantastiquement. Nous reviendrons avec plaisir !",
+      en: "Highly recommended! On our way back from the Ardèche to the Netherlands, we were warmly welcomed and spent two nights in the longère. A wonderful house, everything is there and especially very neat and clean. Table d'hôtes, we had never experienced that before... it was delicious! Rob (and his son) are fantastic cooks. We would love to come back!",
     },
     date: "2025",
   },
@@ -28,6 +30,7 @@ const reviews: Review[] = [
     text: {
       nl: "Slaperij Les deux chevaux voelt voor ons als thuiskomen. Alle credits voor eigenaren Rob en Yvonne die voortreffelijke gastheer en -vrouw zijn en ook nog eens heerlijk kunnen koken. We mogen zelf een plek kiezen voor onze caravan en genieten van de stilte en de natuur.",
       fr: "Les Deux Chevaux, c'est comme rentrer à la maison pour nous. Tous les mérites reviennent aux propriétaires Rob et Yvonne, des hôtes exceptionnels qui cuisinent également délicieusement. Nous pouvons choisir notre emplacement pour notre caravane et profiter du calme et de la nature.",
+      en: "Les Deux Chevaux feels like coming home to us. All credits to owners Rob and Yvonne who are excellent hosts and can also cook deliciously. We can choose our own spot for our caravan and enjoy the silence and nature.",
     },
     date: "2025",
   },
@@ -37,6 +40,7 @@ const reviews: Review[] = [
     text: {
       nl: "Verborgen schat voor de rustzoeker! Geweldige plek met uitzicht op de Puy de Dôme en een geweldige gastvrijheid. Yvonne en Rob doen er werkelijk alles aan het je naar je zin te maken. Rob kan geweldig koken, dus vraag of je kunt aanschuiven. Wij komen er graag weer terug!",
       fr: "Un trésor caché pour ceux qui cherchent le calme ! Endroit magnifique avec vue sur le Puy de Dôme et une hospitalité exceptionnelle. Yvonne et Rob font vraiment tout pour vous satisfaire. Rob cuisine merveilleusement, alors demandez à vous joindre à table. Nous y retournerons avec plaisir !",
+      en: "Hidden gem for those seeking peace! Amazing place with views of the Puy de Dôme and wonderful hospitality. Yvonne and Rob really do everything to make you feel comfortable. Rob is a great cook, so ask if you can join for dinner. We'd love to come back!",
     },
     date: "2025",
   },
@@ -46,6 +50,7 @@ const reviews: Review[] = [
     text: {
       nl: "Wat een enorm leuke camping cq bed and breakfast. Fantastisch leuke, gastvrije en gezellige mensen. Heerlijk eten. Mooie rustige omgeving. En je kan er gewoon Nederlands spreken.",
       fr: "Quel camping et chambre d'hôtes formidable ! Des gens fantastiques, accueillants et chaleureux. Délicieuse cuisine. Un bel environnement calme. Et on peut y parler néerlandais.",
+      en: "What an amazing camping and bed & breakfast. Fantastic, friendly, hospitable and cozy people. Delicious food. Beautiful quiet surroundings. And you can even speak Dutch there.",
     },
     date: "2025",
   },
@@ -76,7 +81,7 @@ export default function Testimonials() {
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
           <h2 className="text-3xl font-bold text-amber-900 mb-4">
-            {locale === "nl" ? "Wat onze gasten zeggen" : "Ce que disent nos hôtes"}
+            {locale === "nl" ? "Wat onze gasten zeggen" : locale === "fr" ? "Ce que disent nos hôtes" : "What our guests say"}
           </h2>
           <div className="flex items-center justify-center gap-2 text-gray-600">
             <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
@@ -111,7 +116,7 @@ export default function Testimonials() {
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 text-amber-700 hover:text-amber-800 font-medium"
           >
-            {locale === "nl" ? "Bekijk alle reviews op Google Maps" : "Voir tous les avis sur Google Maps"}
+            {locale === "nl" ? "Bekijk alle reviews op Google Maps" : locale === "fr" ? "Voir tous les avis sur Google Maps" : "View all reviews on Google Maps"}
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
             </svg>

--- a/src/i18n/LanguageContext.tsx
+++ b/src/i18n/LanguageContext.tsx
@@ -10,10 +10,12 @@ import {
 import type { Locale, Translations } from "./types";
 import nl from "./locales/nl.json";
 import fr from "./locales/fr.json";
+import en from "./locales/en.json";
 
 const translations: Record<Locale, Translations> = {
   nl: nl as Translations,
   fr: fr as Translations,
+  en: en as Translations,
 };
 
 interface LanguageContextType {
@@ -33,7 +35,7 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY) as Locale | null;
-    if (stored && (stored === "nl" || stored === "fr")) {
+    if (stored && (stored === "nl" || stored === "fr" || stored === "en")) {
       setLocaleState(stored);
       document.documentElement.lang = stored;
     }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,333 @@
+{
+  "nav": {
+    "home": "Home",
+    "whoAreWe": "Who are we?",
+    "whereAreWe": "Where are we?",
+    "theRegion": "The region",
+    "whatToExpect": "What to expect?",
+    "rates": "Rates",
+    "contact": "Contact"
+  },
+  "common": {
+    "readMore": "Read more",
+    "contact": "Contact us",
+    "viewRates": "View rates",
+    "openInGoogleMaps": "Open in Google Maps",
+    "allRightsReserved": "All rights reserved",
+    "address": "Address",
+    "navigation": "Navigation",
+    "phone": "Phone",
+    "email": "Email",
+    "interested": "Interested?",
+    "contactUs": "Contact us for more information or to make a reservation.",
+    "location": "Location",
+    "viewOnGoogleMaps": "View on Google Maps",
+    "persons": "persons",
+    "person": "person",
+    "perNight": "per night",
+    "included": "Included",
+    "free": "Free"
+  },
+  "home": {
+    "heroSubtitle": "Gîte, mini-camping, bed & breakfast and table d'hôtes in the Auvergne",
+    "welcomeTitle": "Welcome to the Auvergne",
+    "welcomeText1": "Welcome to the website of Les Deux Chevaux, a sunny gîte, a cozy mini-camping, bed & breakfast and table d'hôtes in the beautiful Auvergne, France.",
+    "welcomeText2": "We, Yvonne and Rob, warmly welcome you to our little piece of paradise in the heart of France.",
+    "whatWeOffer": "What do we offer?",
+    "whyTheName": "Why \"Les Deux Chevaux\"?",
+    "whyTheNameText1": "The name \"Les Deux Chevaux\" refers to the iconic French car, the Citroën 2CV - or \"deux chevaux\" (two horsepower).",
+    "whyTheNameText2": "This car symbolizes the relaxed, authentic French countryside life that we want to offer our guests.",
+    "impressions": "Impressions",
+    "tableSection": {
+      "title": "Table d'Hôtes",
+      "intro": "Table d'hôtes as it should be. Eating together at the long table, a glass of wine, good conversations. Strangers at the start of the evening, friends at the end. Exactly how a holiday should be. Kids are also welcome.",
+      "description": "Enjoy a homemade three-course menu, together at the table, prepared with seasonal products.",
+      "included": "Included",
+      "includedItems": ["Starter", "Main course", "Dessert", "Water", "One glass of wine/beer", "Coffee or tea afterwards"],
+      "price": "€22.50 p.p.",
+      "extras": "Extra drinks (beer, soft drinks): €2.50 per glass • More wine? +€2.50 per glass",
+      "note": "One menu for all guests, please notify allergies in advance.",
+      "kids": "Children up to 10 years: main course + dessert or ice cream — €10.00"
+    },
+    "readyForStay": "Ready for your stay in the Auvergne?",
+    "ctaText": "Contact us for more information or to make a reservation.",
+    "highlights": {
+      "camping": {
+        "title": "Mini-Camping",
+        "description": "6 spacious pitches for tent or caravan in a relaxed atmosphere"
+      },
+      "chambres": {
+        "title": "Gîte / Bed & Breakfast",
+        "description": "Comfortable room or an entire house for yourself"
+      },
+      "table": {
+        "title": "Table d'Hôtes",
+        "description": "Table d'hôtes as it should be. Eating together at the long table, good conversations. Strangers at the start, friends at the end. Three-course menu incl. water, glass of wine/beer and coffee — €22.50 p.p."
+      }
+    }
+  },
+  "whoAreWe": {
+    "heroSubtitle": "Meet Yvonne and Rob",
+    "title": "Yvonne van de Velde & Rob Nijholt",
+    "text1": "At the end of June 2013, we moved from Zierikzee, the Netherlands, to the Auvergne in France to start our dream life.",
+    "text2": "Now we run our mini-camping and bed & breakfast with great pleasure. We warmly welcome you to share the peace and beauty of the Auvergne with us.",
+    "text3": "Whether you come to camp, stay in our Gîte or one of our rooms, or enjoy our table d'hôtes - we make sure you feel at home.",
+    "jipTitle": "Our faithful friend Jip",
+    "jipText": "And then there's Jip, our faithful companion who loves to greet you on arrival! Jip is always happy to meet new guests and ensures a warm welcome.",
+    "sonsTitle": "Reinforcement: the next generation",
+    "sonsText": "For the next two seasons, we're getting help from Paul and Marjolein with their children Mila and Luca. Paul, Rob's son, is taking a gap year to experience adventure in France and help out at Les Deux Chevaux. Whether it's welcoming guests, helping in the kitchen, or maintaining the grounds - with fresh energy and enthusiasm, they complete the team."
+  },
+  "whereAreWe": {
+    "heroSubtitle": "Our location in the heart of the Auvergne",
+    "title": "Nades, Auvergne",
+    "text": "We are located in the picturesque village of Nades (pronounced \"nahd\"), situated in the far south of the Allier department, one of the four departments in the Auvergne region.",
+    "addressTitle": "Address",
+    "addressNote": "This address is recognized by both Google Maps and TomTom navigation systems.",
+    "distances": "Distances",
+    "distance1": "Approximately 60 km north of Clermont-Ferrand",
+    "distance2": "Approximately 750 km from Zierikzee, Netherlands (halfway the southern route)",
+    "directions": "Directions"
+  },
+  "theRegion": {
+    "heroTitle": "What does the region have to offer?",
+    "heroSubtitle": "Discover the beautiful Auvergne",
+    "intro1": "The Auvergne offers year-round beauty with activities for everyone. It's a place where you can truly unwind.",
+    "intro2": "Leave technology behind and enjoy a complete reset in nature.",
+    "outdoorActivities": "Outdoor Activities",
+    "attractionsTitle": "Attractions within 60 km",
+    "winterTitle": "Also in winter",
+    "winterText1": "The Auvergne is also beautiful in winter, with opportunities for winter walks and enjoying the tranquility.",
+    "winterText2": "Enjoy the snowy landscapes and the cozy atmosphere by the fireplace.",
+    "impressions": "Impressions of the region",
+    "activities": {
+      "hiking": {
+        "title": "Hiking",
+        "description": "Numerous trails with various difficulty levels through the beautiful landscape."
+      },
+      "mountainBiking": {
+        "title": "Mountain Biking",
+        "description": "A paradise for MTB enthusiasts with challenging routes."
+      },
+      "cycling": {
+        "title": "Cycling",
+        "description": "Discover the region by bike via scenic roads."
+      },
+      "fishing": {
+        "title": "Fishing",
+        "description": "Fish in the Sioule river or in one of the 2 fishing lakes, rich in various fish species."
+      },
+      "canoeing": {
+        "title": "Canoeing",
+        "description": "Paddle along the Sioule and enjoy nature from the water."
+      },
+      "motorcycling": {
+        "title": "Motorcycle Touring",
+        "description": "Beautiful routes through the hilly landscape of the Auvergne."
+      },
+      "golf": {
+        "title": "Golf",
+        "description": "Several golf courses in the area."
+      },
+      "climbing": {
+        "title": "Climbing",
+        "description": "Adventurous climbing in survival forests."
+      },
+      "swimming": {
+        "title": "Swimming",
+        "description": "Swimming at Plan d'eau de Servant, Lapeyrouse or Saint-Éloy-les-Mines."
+      }
+    },
+    "attractions": {
+      "puyDeDome": {
+        "title": "Puy de Dôme",
+        "description": "Iconic volcano with breathtaking views."
+      },
+      "puyDeSancy": {
+        "title": "Puy de Sancy",
+        "description": "Highest mountain in the Massif Central."
+      },
+      "castles": {
+        "title": "Castles and Ruins",
+        "description": "Rich historical heritage in the area."
+      },
+      "vulcania": {
+        "title": "Parc Vulcania",
+        "description": "Adventure theme park about volcanoes near Clermont-Ferrand."
+      },
+      "autoMuseum": {
+        "title": "Auto Museum Bellenave",
+        "description": "For lovers of classic cars."
+      },
+      "fleaMarkets": {
+        "title": "Flea Markets",
+        "description": "Cozy markets with unique finds."
+      },
+      "shoppingTowns": {
+        "title": "Shopping Towns",
+        "description": "Shopping centers and cozy towns in the area."
+      },
+      "paleopolis": {
+        "title": "Paléopolis (Gannat)",
+        "description": "Dinosaur park with fossils, skeletons, and life-size dinosaurs."
+      },
+      "accrobranche": {
+        "title": "Climbing Parks",
+        "description": "Several accrobranche parks in the area for all ages and levels."
+      },
+      "charroux": {
+        "title": "Charroux",
+        "description": "One of the 'Most Beautiful Villages of France', 10 km away."
+      },
+      "vichy": {
+        "title": "Vichy",
+        "description": "Historic thermal baths and beautiful Belle Époque architecture."
+      },
+      "troncais": {
+        "title": "Forêt de Tronçais",
+        "description": "Largest oak forest in Europe with swimming ponds and hiking trails."
+      }
+    }
+  },
+  "whatToExpect": {
+    "heroTitle": "What can you expect from us?",
+    "heroSubtitle": "Our accommodations and facilities",
+    "intro": "At Les Deux Chevaux, we offer various accommodation options, from camping to luxury rooms, all with the warm hospitality you can expect from us.",
+    "chambresTitle": "Gîte / Bed & Breakfast",
+    "rooms": {
+      "red": {
+        "name": "Red Room",
+        "capacity": "2 persons",
+        "description": "Comfortable and stylishly decorated with private bathroom"
+      },
+      "chezMarco": {
+        "name": "Chez Marco",
+        "capacity": "Up to 6 persons",
+        "description": "Cozy house with 1 bathroom and 2 toilets."
+      },
+      "longere": {
+        "name": "La Longère",
+        "capacity": "2-7 persons",
+        "description": "Spacious holiday home with large, bright living room and equipped kitchen. 2 bathrooms, 2 toilets. Beds made on arrival, towels provided. Private terrace."
+      }
+    },
+    "campingTitle": "Mini-Camping",
+    "campingText": "We have 6 pitches for tents and caravans, with a relaxed atmosphere and all necessary facilities.",
+    "campingFeatures": {
+      "electricity": "Electricity included",
+      "dogs": "Dogs welcome (on leash)",
+      "quiet": "Quiet, green environment",
+      "sanitary": "Shared sanitary facilities"
+    },
+    "additionalTitle": "Additional Accommodation Options",
+    "caravan": {
+      "title": "Small Caravan",
+      "text": "Cozy caravan for 1-2 persons. Ideal for those who want to camp without their own equipment.",
+      "note": "Minimum 2 nights stay"
+    },
+    "bergerie": {
+      "title": "La Bergerie",
+      "text": "A cozy gnome house with a good bed and 2 chairs. Really only for sleeping - sanitary facilities are in the building next door.",
+      "note": "Cozy and romantic"
+    },
+    "tableTitle": "Table d'Hôtes",
+    "tableText": "Our table d'hôtes offers delicious, freshly prepared meals. Enjoy an authentic French dining experience together with other guests.",
+    "tableFeatures": {
+      "dinner": "Three-course dinner with coffee",
+      "fresh": "Freshly prepared meals",
+      "atmosphere": "Cozy atmosphere with other guests"
+    },
+    "impressions": "Impressions"
+  },
+  "rates": {
+    "heroTitle": "Our Rates",
+    "heroSubtitle": "Prices for camping, rooms and meals",
+    "campingTitle": "Camping",
+    "description": "Description",
+    "price": "Price",
+    "campingItems": {
+      "pitch": {
+        "description": "Camping pitch per night",
+        "price": "€20.00"
+      },
+      "electricity": {
+        "description": "Electricity",
+        "price": "Included"
+      },
+      "dog": {
+        "description": "Dog (on leash)",
+        "price": "Free"
+      }
+    },
+    "chambresTitle": "Gîte / Bed & Breakfast",
+    "accommodation": "Accommodation",
+    "pricePerNight": "Price per night",
+    "details": "Details",
+    "chambresItems": {
+      "longere": {
+        "name": "La Longère (gîte)",
+        "price": "from €80/night",
+        "details": "2-7 persons, private bathroom, €40 per extra person"
+      },
+      "chezMarco": {
+        "name": "Chez Marco",
+        "price": "from €80/night",
+        "details": "Up to 6 persons, €40 per extra person"
+      },
+      "smallCaravan": {
+        "name": "Small caravan",
+        "price": "€60.00",
+        "details": "1-2 persons, min. 2 nights"
+      },
+      "luxuryTent": {
+        "name": "Furnished tent",
+        "price": "€60.00",
+        "details": "Min. 2 nights"
+      },
+      "bergerie": {
+        "name": "La Bergerie",
+        "price": "€60.00",
+        "details": "Cozy house, only for sleeping"
+      },
+      "mainRoom": {
+        "name": "Red Room",
+        "price": "€75.00",
+        "details": "2 persons, incl. breakfast, ground floor with private shower/toilet"
+      }
+    },
+    "tableTitle": "Table d'Hôtes (Meals)",
+    "meal": "Meal",
+    "tableItems": {
+      "dinner": {
+        "description": "Three-course dinner with 1 drink, coffee and water",
+        "price": "€22.50 p.p."
+      },
+      "kids": {
+        "description": "Children up to 10 years",
+        "price": "€10.00 p.p."
+      },
+      "drinks": {
+        "description": "Drinks",
+        "price": "€2.50"
+      },
+      "breakfast": {
+        "description": "Breakfast (separate)",
+        "price": "€6.50 p.p."
+      }
+    }
+  },
+  "contact": {
+    "heroSubtitle": "Contact us for more information or a reservation",
+    "contactDetails": "Contact Details",
+    "phoneYvonne": "Phone Yvonne",
+    "phoneRob": "Phone Rob",
+    "viewLocationText": "View our location on Google Maps"
+  },
+  "footer": {
+    "contact": "Contact",
+    "address": "Address",
+    "navigation": "Navigation",
+    "allRightsReserved": "All rights reserved",
+    "rates": "Rates",
+    "theRegion": "The region"
+  }
+}

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1,4 +1,4 @@
-export type Locale = "nl" | "fr";
+export type Locale = "nl" | "fr" | "en";
 
 export interface Translations {
   nav: {


### PR DESCRIPTION
## Summary
Adds English as a third language option alongside Dutch and French.

## Changes
- **New file**: `src/i18n/locales/en.json` - Complete English translations
- **Updated types**: Added `'en'` to `Locale` type
- **LanguageContext**: Imports and includes English translations
- **LanguageToggle**: Updated from NL/FR toggle to NL/FR/EN selector
- **Testimonials**: Added English translations for all 4 reviews
- **FAQ**: Added English translations for all 5 FAQ items
- **Contact page**: Added English for WhatsApp link text

## Test plan
- [ ] Switch to English and verify all pages display correctly
- [ ] Verify language preference is saved in localStorage
- [ ] Check all three languages work in testimonials and FAQ