### PR TITLE
Hide Table d'Hôtes card on mobile

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -82,7 +82,11 @@ export default function Home() {
           </FadeIn>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             {highlights.map((item, index) => (
-              <FadeIn key={item.title} delay={index * 100}>
+              <FadeIn
+                key={item.title}
+                delay={index * 100}
+                className={index === 2 ? "hidden md:block" : undefined}
+              >
                 <Card {...item} />
               </FadeIn>
             ))}


### PR DESCRIPTION
## Summary
- Hides the Table d'Hôtes card in the "What do we offer?" grid on mobile devices
- On mobile, this card was redundant since the detailed Table d'Hôtes section appears right below
- Desktop (md+) still shows all 3 cards

## Changes
- Added `hidden md:block` class to the third card in the highlights grid

## Test plan
- [ ] View homepage on mobile - should see 2 cards (Mini-Camping, Gîte/B&B)
- [ ] View homepage on desktop - should see 3 cards
- [ ] Detailed Table d'Hôtes section still visible on all devices