### PR TITLE
Fix ESLint errors

### DIFF
--- a/src/components/OptimizedImage.tsx
+++ b/src/components/OptimizedImage.tsx
@@ -25,11 +25,6 @@ export function OptimizedImage({
   height,
   onClick,
 }: OptimizedImageProps) {
-  // ExportedImage needs width/height when not using fill
-  const imageProps = fill
-    ? { fill: true }
-    : { width: width || 1920, height: height || 1080 };
-
   // When using fill, don't wrap in an extra div - let the parent handle positioning
   if (fill) {
     return (

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -74,7 +74,7 @@ function StarRating({ rating }: { rating: number }) {
 }
 
 export default function Testimonials() {
-  const { t, locale } = useTranslation();
+  const { locale } = useTranslation();
 
   return (
     <section className="py-16 bg-amber-50">

--- a/src/i18n/LanguageContext.tsx
+++ b/src/i18n/LanguageContext.tsx
@@ -30,21 +30,25 @@ const LanguageContext = createContext<LanguageContextType | undefined>(
 
 const STORAGE_KEY = "lesdeuxchevaux-language";
 
+function getStoredLocale(): Locale {
+  if (typeof window === "undefined") return "nl";
+  const stored = localStorage.getItem(STORAGE_KEY) as Locale | null;
+  if (stored && (stored === "nl" || stored === "fr" || stored === "en")) {
+    return stored;
+  }
+  return "nl";
+}
+
 export function LanguageProvider({ children }: { children: ReactNode }) {
-  const [locale, setLocaleState] = useState<Locale>("nl");
+  const [locale, setLocaleState] = useState<Locale>(getStoredLocale);
 
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY) as Locale | null;
-    if (stored && (stored === "nl" || stored === "fr" || stored === "en")) {
-      setLocaleState(stored);
-      document.documentElement.lang = stored;
-    }
-  }, []);
+    document.documentElement.lang = locale;
+  }, [locale]);
 
   const setLocale = (newLocale: Locale) => {
     setLocaleState(newLocale);
     localStorage.setItem(STORAGE_KEY, newLocale);
-    document.documentElement.lang = newLocale;
   };
 
   const value: LanguageContextType = {


### PR DESCRIPTION
## Summary
Fixes all ESLint errors in the codebase.

## Changes
- **OptimizedImage.tsx**: Remove unused `imageProps` variable
- **Testimonials.tsx**: Remove unused `t` from destructure (only `locale` is used)
- **LanguageContext.tsx**: Refactor to use lazy state initializer instead of calling setState in useEffect, avoiding cascading renders

## Verification
- `bun run lint` passes with no errors
- `bun run build` succeeds