### PR TITLE
Fix Dutch rates details copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build && next-image-export-optimizer",
     "start": "next start",
+    "test": "node --test",
     "lint": "eslint"
   },
   "dependencies": {

--- a/src/app/tarieven/page.tsx
+++ b/src/app/tarieven/page.tsx
@@ -94,7 +94,7 @@ export default function Tarieven() {
                   <td className="px-4 py-3 text-right font-semibold text-amber-700">
                     {t.rates.chambresItems.longere.price}
                   </td>
-                  <td className="px-4 py-3 text-gray-600">
+                  <td className="px-4 py-3 text-gray-600 whitespace-pre-line">
                     {t.rates.chambresItems.longere.details}
                   </td>
                 </tr>
@@ -105,7 +105,7 @@ export default function Tarieven() {
                   <td className="px-4 py-3 text-right font-semibold text-amber-700">
                     {t.rates.chambresItems.chezMarco.price}
                   </td>
-                  <td className="px-4 py-3 text-gray-600">
+                  <td className="px-4 py-3 text-gray-600 whitespace-pre-line">
                     {t.rates.chambresItems.chezMarco.details}
                   </td>
                 </tr>
@@ -116,7 +116,7 @@ export default function Tarieven() {
                   <td className="px-4 py-3 text-right font-semibold text-amber-700">
                     {t.rates.chambresItems.mainRoom.price}
                   </td>
-                  <td className="px-4 py-3 text-gray-600">
+                  <td className="px-4 py-3 text-gray-600 whitespace-pre-line">
                     {t.rates.chambresItems.mainRoom.details}
                   </td>
                 </tr>
@@ -127,7 +127,7 @@ export default function Tarieven() {
                   <td className="px-4 py-3 text-right font-semibold text-amber-700">
                     {t.rates.chambresItems.smallCaravan.price}
                   </td>
-                  <td className="px-4 py-3 text-gray-600">
+                  <td className="px-4 py-3 text-gray-600 whitespace-pre-line">
                     {t.rates.chambresItems.smallCaravan.details}
                   </td>
                 </tr>
@@ -138,7 +138,7 @@ export default function Tarieven() {
                   <td className="px-4 py-3 text-right font-semibold text-amber-700">
                     {t.rates.chambresItems.luxuryTent.price}
                   </td>
-                  <td className="px-4 py-3 text-gray-600">
+                  <td className="px-4 py-3 text-gray-600 whitespace-pre-line">
                     {t.rates.chambresItems.luxuryTent.details}
                   </td>
                 </tr>
@@ -149,7 +149,7 @@ export default function Tarieven() {
                   <td className="px-4 py-3 text-right font-semibold text-amber-700">
                     {t.rates.chambresItems.bergerie.price}
                   </td>
-                  <td className="px-4 py-3 text-gray-600">
+                  <td className="px-4 py-3 text-gray-600 whitespace-pre-line">
                     {t.rates.chambresItems.bergerie.details}
                   </td>
                 </tr>

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -265,13 +265,13 @@
     "chambresItems": {
       "longere": {
         "name": "La Longère (gîte)",
-        "price": "vanaf €80/nacht",
-        "details": "2-7 personen, eigen badkamer, €40 per extra persoon"
+        "price": "€80",
+        "details": "Basisprijs voor 2 personen.\nExtra volwassene of kind: + € 40,00 p.p.p.n\n(Geschikt voor 2-7 personen, eigen badkamer)"
       },
       "chezMarco": {
         "name": "Chez Marco",
-        "price": "vanaf €80/nacht",
-        "details": "Tot 6 personen, €40 per extra persoon"
+        "price": "€80",
+        "details": "Basisprijs voor 2 personen.\nExtra volwassene of kind: + € 40,00 p.p.p.n\n(Geschikt tot 6 personen)"
       },
       "smallCaravan": {
         "name": "Kleine caravan",

--- a/test/rates-copy.test.mjs
+++ b/test/rates-copy.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, it } from "node:test";
+
+const locale = JSON.parse(
+  await readFile(new URL("../src/i18n/locales/nl.json", import.meta.url), "utf8")
+);
+const ratesPage = await readFile(
+  new URL("../src/app/tarieven/page.tsx", import.meta.url),
+  "utf8"
+);
+
+describe("Dutch rates copy", () => {
+  it("matches the requested lodging price and detail text", () => {
+    assert.deepEqual(locale.rates.chambresItems.longere, {
+      name: "La Longère (gîte)",
+      price: "€80",
+      details:
+        "Basisprijs voor 2 personen.\nExtra volwassene of kind: + € 40,00 p.p.p.n\n(Geschikt voor 2-7 personen, eigen badkamer)",
+    });
+
+    assert.deepEqual(locale.rates.chambresItems.chezMarco, {
+      name: "Chez Marco",
+      price: "€80",
+      details:
+        "Basisprijs voor 2 personen.\nExtra volwassene of kind: + € 40,00 p.p.p.n\n(Geschikt tot 6 personen)",
+    });
+  });
+
+  it("preserves line breaks in lodging detail cells", () => {
+    assert.match(ratesPage, /whitespace-pre-line/);
+  });
+});


### PR DESCRIPTION
## Summary
- Update Dutch prices for La Longère and Chez Marco to €80
- Replace their rates details with the requested multiline copy
- Preserve line breaks in lodging detail cells and add a regression test

## Test Plan
- [x] npm test
- [x] npm run lint
- [x] npm run build

Closes #99