### PR TITLE
Twee foto's rechtzetten

### DIFF
--- a/public/uploads/2026/eten/bord-spies-aardappel.jpg
+++ b/public/uploads/2026/eten/bord-spies-aardappel.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:321eb664895fd2368eefb22a95336b59f92157060363b2ee452a9b5c1fbf96be
-size 549279
+oid sha256:ddedc35209a2e05b724c21346b234376da19d0726e5e35fccc430bcd12a8f51b
+size 626614

--- a/public/uploads/2026/eten/quiche-pannetje.jpg
+++ b/public/uploads/2026/eten/quiche-pannetje.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fffb04507e1b3ec775a6cbcdb0f671c297996e7627750ef92250916895fdb1c2
-size 524569
+oid sha256:61bad67645c9c171c7d1c529b1fb8288a8658ee1c7a002ef75746ad4aa4605b5
+size 512601

--- a/public/uploads/2026/eten/quiche-pannetje.jpg
+++ b/public/uploads/2026/eten/quiche-pannetje.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e9a67c532e6f425d2b7a8720fb554d1da7586e1f034776ef7d3adaf767a712b2
-size 454099
+oid sha256:fffb04507e1b3ec775a6cbcdb0f671c297996e7627750ef92250916895fdb1c2
+size 524569

--- a/public/uploads/2026/eten/stoofpot-gietijzer.jpg
+++ b/public/uploads/2026/eten/stoofpot-gietijzer.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c58bfad05ef4a917e35875707db9ca2a7990f0038b011b0b6d72369a04b1e02
-size 378678
+oid sha256:f98a5ffe29fae6a71c63f90ef31179a99eda5e5ccaf564326439f6a39bd170c1
+size 435663


### PR DESCRIPTION
De quiche in het gietijzeren pannetje en de foto met spies en gepofte aardappel stonden gekanteld. Beide een kwartslag naar links gedraaid.