### PR TITLE
Verwijder kleine caravan van de website

### DIFF
--- a/src/app/tarieven/page.tsx
+++ b/src/app/tarieven/page.tsx
@@ -121,17 +121,7 @@ export default function Tarieven() {
                     {t.rates.chambresItems.mainRoom.details}
                   </td>
                 </tr>
-                <tr className="hover:bg-amber-50">
-                  <td className="px-4 py-3 font-medium">
-                    {t.rates.chambresItems.smallCaravan.name}
-                  </td>
-                  <td className="px-4 py-3 text-right font-semibold text-amber-700">
-                    {t.rates.chambresItems.smallCaravan.price}
-                  </td>
-                  <td className="px-4 py-3 text-gray-600 whitespace-pre-line">
-                    {t.rates.chambresItems.smallCaravan.details}
-                  </td>
-                </tr>
+
                 <tr className="hover:bg-amber-50">
                   <td className="px-4 py-3 font-medium">
                     {t.rates.chambresItems.luxuryTent.name}

--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -179,17 +179,6 @@ export default function WatTeVerwachten() {
             </div>
           </div>
 
-          {/* Kleine Caravan */}
-          <div className="bg-amber-50 p-8 rounded-xl shadow-sm mb-8">
-            <h3 className="text-2xl font-semibold text-amber-800 mb-4">
-              {t.whatToExpect.caravan.title}
-            </h3>
-            <p className="text-gray-600 mb-4">{t.whatToExpect.caravan.text}</p>
-            <p className="text-amber-600 font-medium">
-              {t.whatToExpect.caravan.note}
-            </p>
-          </div>
-
           {/* La Bergerie */}
           <div className="mb-8">
             <h3 className="text-2xl font-semibold text-amber-800 mb-4">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -228,11 +228,6 @@
       "sanitary": "Shared sanitary facilities"
     },
     "additionalTitle": "Additional Accommodation Options",
-    "caravan": {
-      "title": "Small Caravan",
-      "text": "Cozy caravan for 1-2 persons. Ideal for those who want to camp without their own equipment.",
-      "note": ""
-    },
     "bergerie": {
       "title": "La Bergerie",
       "text": "A cozy gnome house with a good bed and 2 chairs. Really only for sleeping - sanitary facilities are in the building next door.",
@@ -286,11 +281,6 @@
         "name": "Le Bel Etage",
         "price": "from €80/night",
         "details": "Up to 6 persons, €40 per extra person"
-      },
-      "smallCaravan": {
-        "name": "Small caravan",
-        "price": "€60.00",
-        "details": "1-2 persons"
       },
       "luxuryTent": {
         "name": "Furnished tent",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -228,11 +228,6 @@
       "sanitary": "Sanitaires partagés"
     },
     "additionalTitle": "Options d'hébergement supplémentaires",
-    "caravan": {
-      "title": "Petite Caravane",
-      "text": "Caravane confortable pour 1-2 personnes. Idéale pour camper sans son propre équipement.",
-      "note": ""
-    },
     "bergerie": {
       "title": "La Bergerie",
       "text": "Une petite maison de gnome accueillante avec un bon lit et 2 chaises. Uniquement pour dormir - sanitaires dans le bâtiment adjacent.",
@@ -286,11 +281,6 @@
         "name": "Le Bel Etage",
         "price": "à partir de 80€/nuit",
         "details": "Jusqu'à 6 personnes, 40€ par personne supplémentaire"
-      },
-      "smallCaravan": {
-        "name": "Petite caravane",
-        "price": "60,00 €",
-        "details": "1-2 personnes"
       },
       "luxuryTent": {
         "name": "Tente équipée",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -228,11 +228,6 @@
       "sanitary": "Gedeelde sanitaire voorzieningen"
     },
     "additionalTitle": "Aanvullende Verblijfsopties",
-    "caravan": {
-      "title": "Kleine Caravan",
-      "text": "Gezellige caravan voor 1-2 personen. Ideaal voor wie wil kamperen zonder eigen spullen.",
-      "note": ""
-    },
     "bergerie": {
       "title": "La Bergerie",
       "text": "Een gezellig kabouterhuisje met een goed bed en 2 stoelen. Echt alleen om in te slapen - sanitair bevindt zich in het gebouwtje ernaast.",
@@ -286,11 +281,6 @@
         "name": "Le Bel Etage",
         "price": "€80",
         "details": "Basisprijs voor 2 personen.\nExtra volwassene of kind: + € 40 p.p.p.n\n(Geschikt tot 6 personen)"
-      },
-      "smallCaravan": {
-        "name": "Kleine caravan",
-        "price": "€60",
-        "details": "1-2 personen"
       },
       "luxuryTent": {
         "name": "Ingerichte tent",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -145,11 +145,6 @@ export interface Translations {
       text: string;
       note: string;
     };
-    caravan: {
-      title: string;
-      text: string;
-      note: string;
-    };
     bergerie: {
       title: string;
       text: string;
@@ -183,7 +178,6 @@ export interface Translations {
       mainRoom: { name: string; price: string; details: string };
       longere: { name: string; price: string; details: string };
       chezMarco: { name: string; price: string; details: string };
-      smallCaravan: { name: string; price: string; details: string };
       luxuryTent: { name: string; price: string; details: string };
       bergerie: { name: string; price: string; details: string };
     };


### PR DESCRIPTION
De kleine caravan is niet meer beschikbaar voor gasten en wordt daarom verwijderd van Wat te verwachten en Tarieven, in alle drie de talen.