### PR TITLE
Verbeter de foto’s van La Longère

### DIFF
--- a/public/uploads/2026/09/longere-badkamer-1.jpg
+++ b/public/uploads/2026/09/longere-badkamer-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b1e5578d8167ca03529d2e0f003e35bc2f6294a61bd43be6b0178f1681db3b3
+size 267255

--- a/public/uploads/2026/09/longere-badkamer-2.jpg
+++ b/public/uploads/2026/09/longere-badkamer-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcfcc412c1c7f06ab13f440d60eb2466390b636da5a530b351ac93c88dd4d3ce
+size 235025

--- a/public/uploads/2026/09/longere-eetkamer.jpg
+++ b/public/uploads/2026/09/longere-eetkamer.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:446b128e3c8b491a5ec3e73365631f65a4a6aaf82e551a947df69d2b50484bbb
+size 425412

--- a/public/uploads/2026/09/longere-keuken.jpg
+++ b/public/uploads/2026/09/longere-keuken.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:446b128e3c8b491a5ec3e73365631f65a4a6aaf82e551a947df69d2b50484bbb
+size 425412

--- a/public/uploads/2026/09/longere-leefruimte.jpg
+++ b/public/uploads/2026/09/longere-leefruimte.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9052212ad18cb1641001f3467a49a32e9e23a336c143a82610cbc8a7c8b2051
+size 397735

--- a/public/uploads/2026/09/longere-slaapkamer-2.jpg
+++ b/public/uploads/2026/09/longere-slaapkamer-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9ef7bb5e626318d5006d4de2a9f140797d12ae9aa82aa687b3b9c93a7f419c7
+size 449941

--- a/public/uploads/2026/09/longere-slaapkamer.jpg
+++ b/public/uploads/2026/09/longere-slaapkamer.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e5052b0dfdcb24e6866b1c1a2d754e781eb9f35ba50b15a63d5e2ff1df261dc
+size 515913

--- a/public/uploads/2026/09/longere-terras.jpg
+++ b/public/uploads/2026/09/longere-terras.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ae01ae3de1707d31bbdd549d073ea35649acc9d19c2342bd8ff4a9d1313ae0cf
-size 690762
+oid sha256:5cddc26d8e18e2ba163f91362e6f55769d3db65abe98c097cee638f7d6583662
+size 692605

--- a/public/uploads/2026/09/longere-terras.jpg
+++ b/public/uploads/2026/09/longere-terras.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5cddc26d8e18e2ba163f91362e6f55769d3db65abe98c097cee638f7d6583662
-size 692605
+oid sha256:3d627ebea99eee08af33ef1577a71d684acca92d76b985fb0fb4ad49fa5ee6e0
+size 695675

--- a/public/uploads/2026/09/longere-terras.jpg
+++ b/public/uploads/2026/09/longere-terras.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cddc26d8e18e2ba163f91362e6f55769d3db65abe98c097cee638f7d6583662
+size 692605

--- a/public/uploads/2026/09/longere-terras.jpg
+++ b/public/uploads/2026/09/longere-terras.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5cddc26d8e18e2ba163f91362e6f55769d3db65abe98c097cee638f7d6583662
-size 692605
+oid sha256:ae01ae3de1707d31bbdd549d073ea35649acc9d19c2342bd8ff4a9d1313ae0cf
+size 690762

--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -11,7 +11,7 @@ const longereImages = [
   { src: "/uploads/2026/01/longere-2.jpg", alt: "Eethoek van La Longère" },
   { src: "/uploads/2026/09/longere-slaapkamer.jpg", alt: "Slaapkamer van La Longère" },
   { src: "/uploads/2026/09/longere-slaapkamer-2.jpg", alt: "Tweede slaapkamer van La Longère" },
-  { src: "/uploads/2026/01/longere-3.jpg", alt: "Keuken van La Longère" },
+  { src: "/uploads/2026/09/longere-keuken.jpg", alt: "Keuken van La Longère" },
   { src: "/uploads/2026/09/longere-badkamer-2.jpg", alt: "Badkamer van La Longère" },
   { src: "/uploads/2026/09/longere-terras.jpg", alt: "Terras van La Longère" },
   { src: "/uploads/2026/01/longere-5.jpg", alt: "Lichte hal van La Longère" },

--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -9,9 +9,9 @@ import { useTranslation } from "@/i18n";
 const longereImages = [
   { src: "/uploads/2026/01/longere-1.jpg", alt: "Woonkamer van La Longère" },
   { src: "/uploads/2026/01/longere-2.jpg", alt: "Eethoek van La Longère" },
+  { src: "/uploads/2026/09/longere-keuken.jpg", alt: "Keuken van La Longère" },
   { src: "/uploads/2026/09/longere-slaapkamer.jpg", alt: "Slaapkamer van La Longère" },
   { src: "/uploads/2026/09/longere-slaapkamer-2.jpg", alt: "Tweede slaapkamer van La Longère" },
-  { src: "/uploads/2026/09/longere-keuken.jpg", alt: "Keuken van La Longère" },
   { src: "/uploads/2026/09/longere-badkamer-2.jpg", alt: "Badkamer van La Longère" },
   { src: "/uploads/2026/09/longere-terras.jpg", alt: "Terras van La Longère" },
   { src: "/uploads/2026/01/longere-5.jpg", alt: "Lichte hal van La Longère" },

--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from "@/i18n";
 
 const longereImages = [
   { src: "/uploads/2026/09/longere-leefruimte.jpg", alt: "Woonkamer van La Longère" },
-  { src: "/uploads/2026/09/longere-eetkamer.jpg", alt: "Eetkamer van La Longère" },
   { src: "/uploads/2026/09/longere-slaapkamer.jpg", alt: "Slaapkamer van La Longère" },
   { src: "/uploads/2026/09/longere-slaapkamer-2.jpg", alt: "Tweede slaapkamer van La Longère" },
   { src: "/uploads/2026/01/longere-3.jpg", alt: "Keuken van La Longère" },

--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -12,7 +12,6 @@ const longereImages = [
   { src: "/uploads/2026/09/longere-slaapkamer-2.jpg", alt: "Tweede slaapkamer van La Longère" },
   { src: "/uploads/2026/01/longere-3.jpg", alt: "Keuken van La Longère" },
   { src: "/uploads/2026/09/longere-badkamer-1.jpg", alt: "Badkamer van La Longère" },
-  { src: "/uploads/2026/09/longere-badkamer-2.jpg", alt: "Tweede beeld van de badkamer van La Longère" },
   { src: "/uploads/2026/09/longere-terras.jpg", alt: "Terras van La Longère" },
 ];
 

--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -8,10 +8,11 @@ import { useTranslation } from "@/i18n";
 
 const longereImages = [
   { src: "/uploads/2026/09/longere-leefruimte.jpg", alt: "Woonkamer van La Longère" },
+  { src: "/uploads/2026/01/longere-1.jpg", alt: "Woonkamer en eetruimte van La Longère" },
   { src: "/uploads/2026/09/longere-slaapkamer.jpg", alt: "Slaapkamer van La Longère" },
   { src: "/uploads/2026/09/longere-slaapkamer-2.jpg", alt: "Tweede slaapkamer van La Longère" },
   { src: "/uploads/2026/01/longere-3.jpg", alt: "Keuken van La Longère" },
-  { src: "/uploads/2026/09/longere-badkamer-1.jpg", alt: "Badkamer van La Longère" },
+  { src: "/uploads/2026/09/longere-badkamer-2.jpg", alt: "Badkamer van La Longère" },
   { src: "/uploads/2026/09/longere-terras.jpg", alt: "Terras van La Longère" },
 ];
 

--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -9,11 +9,13 @@ import { useTranslation } from "@/i18n";
 const longereImages = [
   { src: "/uploads/2026/09/longere-leefruimte.jpg", alt: "Woonkamer van La Longère" },
   { src: "/uploads/2026/01/longere-1.jpg", alt: "Woonkamer en eetruimte van La Longère" },
+  { src: "/uploads/2026/01/longere-2.jpg", alt: "Eethoek van La Longère" },
   { src: "/uploads/2026/09/longere-slaapkamer.jpg", alt: "Slaapkamer van La Longère" },
   { src: "/uploads/2026/09/longere-slaapkamer-2.jpg", alt: "Tweede slaapkamer van La Longère" },
   { src: "/uploads/2026/01/longere-3.jpg", alt: "Keuken van La Longère" },
   { src: "/uploads/2026/09/longere-badkamer-2.jpg", alt: "Badkamer van La Longère" },
   { src: "/uploads/2026/09/longere-terras.jpg", alt: "Terras van La Longère" },
+  { src: "/uploads/2026/01/longere-5.jpg", alt: "Lichte hal van La Longère" },
 ];
 
 const chezMarcoImages = [

--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -10,6 +10,7 @@ const longereImages = [
   { src: "/uploads/2026/09/longere-leefruimte.jpg", alt: "Leefruimte van La Longère" },
   { src: "/uploads/2026/09/longere-eetkamer.jpg", alt: "Eetkamer van La Longère" },
   { src: "/uploads/2026/09/longere-slaapkamer.jpg", alt: "Slaapkamer van La Longère" },
+  { src: "/uploads/2026/09/longere-slaapkamer-2.jpg", alt: "Tweede slaapkamer van La Longère" },
   { src: "/uploads/2026/01/longere-3.jpg", alt: "Keuken van La Longère" },
   { src: "/uploads/2026/09/longere-badkamer-1.jpg", alt: "Badkamer van La Longère" },
   { src: "/uploads/2026/09/longere-badkamer-2.jpg", alt: "Tweede beeld van de badkamer van La Longère" },

--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -65,7 +65,7 @@ export default function WatTeVerwachten() {
       <Hero
         title={t.whatToExpect.heroTitle}
         subtitle={t.whatToExpect.heroSubtitle}
-        image="/uploads/2016/09/huis.jpeg"
+        image="/uploads/2026/01/chambres-dhotes.jpg"
       />
 
       {/* Introduction */}

--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -7,8 +7,7 @@ import ReserveButton from "@/components/ReserveButton";
 import { useTranslation } from "@/i18n";
 
 const longereImages = [
-  { src: "/uploads/2026/09/longere-leefruimte.jpg", alt: "Woonkamer van La Longère" },
-  { src: "/uploads/2026/01/longere-1.jpg", alt: "Woonkamer en eetruimte van La Longère" },
+  { src: "/uploads/2026/01/longere-1.jpg", alt: "Woonkamer van La Longère" },
   { src: "/uploads/2026/01/longere-2.jpg", alt: "Eethoek van La Longère" },
   { src: "/uploads/2026/09/longere-slaapkamer.jpg", alt: "Slaapkamer van La Longère" },
   { src: "/uploads/2026/09/longere-slaapkamer-2.jpg", alt: "Tweede slaapkamer van La Longère" },

--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -7,7 +7,7 @@ import ReserveButton from "@/components/ReserveButton";
 import { useTranslation } from "@/i18n";
 
 const longereImages = [
-  { src: "/uploads/2026/09/longere-leefruimte.jpg", alt: "Leefruimte van La Longère" },
+  { src: "/uploads/2026/09/longere-leefruimte.jpg", alt: "Woonkamer van La Longère" },
   { src: "/uploads/2026/09/longere-eetkamer.jpg", alt: "Eetkamer van La Longère" },
   { src: "/uploads/2026/09/longere-slaapkamer.jpg", alt: "Slaapkamer van La Longère" },
   { src: "/uploads/2026/09/longere-slaapkamer-2.jpg", alt: "Tweede slaapkamer van La Longère" },

--- a/src/app/wat-te-verwachten/page.tsx
+++ b/src/app/wat-te-verwachten/page.tsx
@@ -7,11 +7,13 @@ import ReserveButton from "@/components/ReserveButton";
 import { useTranslation } from "@/i18n";
 
 const longereImages = [
-  { src: "/uploads/2026/01/longere-1.jpg", alt: "La Longère interieur" },
-  { src: "/uploads/2026/01/longere-2.jpg", alt: "La Longère slaapkamer" },
-  { src: "/uploads/2026/01/longere-3.jpg", alt: "La Longère keuken" },
-  { src: "/uploads/2026/01/longere-4.jpg", alt: "La Longère woonkamer" },
-  { src: "/uploads/2026/01/longere-5.jpg", alt: "La Longère badkamer" },
+  { src: "/uploads/2026/09/longere-leefruimte.jpg", alt: "Leefruimte van La Longère" },
+  { src: "/uploads/2026/09/longere-eetkamer.jpg", alt: "Eetkamer van La Longère" },
+  { src: "/uploads/2026/09/longere-slaapkamer.jpg", alt: "Slaapkamer van La Longère" },
+  { src: "/uploads/2026/01/longere-3.jpg", alt: "Keuken van La Longère" },
+  { src: "/uploads/2026/09/longere-badkamer-1.jpg", alt: "Badkamer van La Longère" },
+  { src: "/uploads/2026/09/longere-badkamer-2.jpg", alt: "Tweede beeld van de badkamer van La Longère" },
+  { src: "/uploads/2026/09/longere-terras.jpg", alt: "Terras van La Longère" },
 ];
 
 const chezMarcoImages = [


### PR DESCRIPTION
Vervangt de huidige La Longère-galerij door een selectie met betere foto’s van de leefruimte, eetkamer, slaapkamer, badkamer en terras. De bestaande keukenfoto blijft behouden. Nog niet live; eerst preview bekijken.